### PR TITLE
Handle map in another package and add test

### DIFF
--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -304,11 +304,9 @@ start:
 	// Maps
 	case *ast.MapType:
 		// As far as I can find there is no obvious/elegant way to represent
-		// this in JSON schema, so simply don't support it for now. I don't
-		// think we actually use this anywhere.
-		// TODO: We should really support this...
-		//return nil, errors.New("fieldToSchema: maps are not supported due to JSON schema limitations")
+		// this in JSON schema, so it's just an object.
 		p.Type = "object"
+		return &p, nil
 
 	// Array and slices.
 	case *ast.ArrayType:

--- a/testdata/openapi2/src/struct-map/in.go
+++ b/testdata/openapi2/src/struct-map/in.go
@@ -1,0 +1,22 @@
+package path
+
+import "struct-map/otherpkg"
+
+type resp struct {
+	Basic       map[string]interface{} `json:"basic"`       // Basic comment.
+	Custom      myMap                  `json:"custom"`      // Custom comment.
+	Struct      aStruct                `json:"aStruct"`     // Struct comment.
+	OtherStruct otherpkg.OtherStruct   `json:"otherStruct"` // OtherStruct comment.
+}
+
+// Comments are lost here as its just in the doc as an object.
+type myMap map[int]string
+
+type aStruct struct {
+	Foo string         `json:"foo"`
+	Bar otherpkg.MyMap `json:"bar"`
+}
+
+// POST /path
+//
+// Response 200: $ref: resp

--- a/testdata/openapi2/src/struct-map/otherpkg/in.go
+++ b/testdata/openapi2/src/struct-map/otherpkg/in.go
@@ -1,0 +1,10 @@
+package otherpkg
+
+// No docs from here, it doesn't have its own definition.
+type MyMap map[int64]map[string]interface{}
+
+// OtherStruct is a struct in another package.
+type OtherStruct struct {
+	// Map contains some random data :)
+	Map MyMap `json:"map"`
+}

--- a/testdata/openapi2/src/struct-map/want.yaml
+++ b/testdata/openapi2/src/struct-map/want.yaml
@@ -1,0 +1,50 @@
+swagger: "2.0"
+info:
+  title: x
+  version: x
+consumes:
+- application/json
+produces:
+- application/json
+paths:
+  /path:
+    post:
+      operationId: POST_path
+      produces:
+      - application/json
+      responses:
+        200:
+          description: 200 OK
+          schema:
+            $ref: '#/definitions/struct-map.resp'
+definitions:
+  otherpkg.OtherStruct:
+    title: OtherStruct
+    description: OtherStruct is a struct in another package.
+    type: object
+    properties:
+      map:
+        description: Map contains some random data :)
+        type: object
+  struct-map.aStruct:
+    title: aStruct
+    type: object
+    properties:
+      bar:
+        type: object
+      foo:
+        type: string
+  struct-map.resp:
+    title: resp
+    type: object
+    properties:
+      aStruct:
+        $ref: '#/definitions/struct-map.aStruct'
+      basic:
+        description: Basic comment.
+        type: object
+      custom:
+        description: Custom comment.
+        type: object
+      otherStruct:
+        $ref: '#/definitions/otherpkg.OtherStruct'


### PR DESCRIPTION
Returns early to avoid a reference being set, a map will just be an object in
the response.

See `want.yml` for output when using maps, before the early return it was adding a reference which could be invalid as we never added a reference for the map. There isn't really any reference to be added for a map (could add one with just description like the interface pr but doesn't seem as simple to change) so instead its just an object.

This was causing me an issue as we had a field that was a map type defined in another package so it was looking for a definition that wasn't there.