### PR TITLE
Fix parsing types declared in a type block

### DIFF
--- a/docparse/find.go
+++ b/docparse/find.go
@@ -189,7 +189,6 @@ func findType(currentFile, pkgPath, name string) (
 								}
 
 								decls = append(decls, declCache{ts, path})
-								break
 							}
 						}
 					}
@@ -257,7 +256,7 @@ func GetReference(prog *Program, context, lookup, filePath string) (*Reference, 
 
 	// Already parsed this one, don't need to do it again.
 	if ref, ok := prog.References[lookup]; ok {
-		// Update context: some structs are embeded but also referenced
+		// Update context: some structs are embedded but also referenced
 		// directly.
 		if ref.Context == ContextEmbed {
 			ref.Context = context
@@ -353,7 +352,7 @@ func GetReference(prog *Program, context, lookup, filePath string) (*Reference, 
 		}
 	}
 
-	// Add in embeded structs with a tag.
+	// Add in embedded structs with a tag.
 	for _, n := range nestedTagged {
 		ename := goutil.TagName(n, "json") // TODO: don't hard-code json
 		n.Names = []*ast.Ident{&ast.Ident{
@@ -372,7 +371,7 @@ func GetReference(prog *Program, context, lookup, filePath string) (*Reference, 
 	}
 	ref.Schema = schema
 
-	// Merge for embeded structs without a tag.
+	// Merge for embedded structs without a tag.
 	for _, n := range nested {
 		ref.Fields = append(ref.Fields, prog.References[n].Fields...)
 

--- a/testdata/openapi2/src/type-block/in.go
+++ b/testdata/openapi2/src/type-block/in.go
@@ -1,0 +1,11 @@
+package req
+
+type (
+	foo    struct{}
+	reqRef struct{}
+)
+
+// POST /path
+//
+// Request body: $ref: reqRef
+// Response 200: $empty

--- a/testdata/openapi2/src/type-block/want.yaml
+++ b/testdata/openapi2/src/type-block/want.yaml
@@ -1,0 +1,29 @@
+swagger: "2.0"
+info:
+  title: x
+  version: x
+consumes:
+- application/json
+produces:
+- application/json
+paths:
+  /path:
+    post:
+      operationId: POST_path
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - name: type-block.reqRef
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/type-block.reqRef'
+      responses:
+        200:
+          description: 200 OK
+definitions:
+  type-block.reqRef:
+    title: reqRef
+    type: object


### PR DESCRIPTION
It would fail on:

	type (
		one struct{}
		two struct{}
	)

Because it would break out of the "for _, s := range gd.Specs" loop it
would only parse the first one.