### PR TITLE
Support setting Basepath

### DIFF
--- a/config.example
+++ b/config.example
@@ -29,7 +29,14 @@ default-response-ct application/json
 #default-response 404 $ref: github.com/teamwork/echoutil/errorhandler.Error
 
 # Prefix all paths with this.
-prefix /desk/
+#prefix /desk
+
+# Set output basepath; this is different from "prefix" because the former
+# modifies every path before it gets added to the output, whereas this will only
+# set the basePath attribute in the output if the output format supports it.
+# If the output format doesn't support Basepath, it is added to every endpoint
+# *before* the Prefix.
+basepath /desk
 
 
 # vim:ft=config

--- a/docparse/docparse.go
+++ b/docparse/docparse.go
@@ -45,6 +45,7 @@ type Config struct {
 	DefaultResponseCt string
 	DefaultResponse   map[int]DefaultResponse
 	Prefix            string
+	Basepath          string
 }
 
 // DefaultResponse references.

--- a/html/html.go
+++ b/html/html.go
@@ -288,7 +288,7 @@ var mainTpl = template.Must(template.New("mainTpl").Funcs(funcMap).Parse(`
 func WriteHTML(w io.Writer, prog *docparse.Program) error {
 	// Too hard to write template otherwise.
 	for i := range prog.Endpoints {
-		prog.Endpoints[i].Path = prog.Config.Prefix + prog.Endpoints[i].Path
+		prog.Endpoints[i].Path = prog.Config.Basepath + prog.Config.Prefix + prog.Endpoints[i].Path
 
 		if len(prog.Endpoints[i].Tags) == 0 {
 			prog.Endpoints[i].Tags = []string{"default"}

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -119,7 +119,8 @@ var reParams = regexp.MustCompile(`{\w+}`)
 
 func write(outFormat string, w io.Writer, prog *docparse.Program) error {
 	out := OpenAPI{
-		Swagger: "2.0",
+		Swagger:  "2.0",
+		BasePath: prog.Config.Basepath,
 		Info: Info{
 			Title:       prog.Config.Title,
 			Description: string(prog.Config.Description),


### PR DESCRIPTION
Stoplight.io will look at the pathnames for grouping, and ignored the
tags we set. So if everything is prefixed with "/desk" it will stuff
everything in a "Desk" group.

This is spectacularly wrong, but it's what we have to deal with...