### PR TITLE
Add failing test case for inline struct lookups

### DIFF
--- a/docparse/find.go
+++ b/docparse/find.go
@@ -129,7 +129,7 @@ func findType(currentFile, pkgPath, name string) (
 	importPath string,
 	err error,
 ) {
-	dbg("FindType: file: %#v, pkgPath: %#v, name: %#v", currentFile, pkgPath, name)
+	dbg("findType: file: %#v, pkgPath: %#v, name: %#v", currentFile, pkgPath, name)
 
 	pkg, err := goutil.ResolvePackage(pkgPath, 0)
 	if err != nil && currentFile != "" {
@@ -150,7 +150,7 @@ func findType(currentFile, pkgPath, name string) (
 	decls, ok := declsCache[pkgPath]
 	if !ok {
 		fset := token.NewFileSet()
-		dbg("FindType: parsing dir %#v: %#v", pkg.Dir, pkg.GoFiles)
+		dbg("findType: parsing dir %#v: %#v", pkg.Dir, pkg.GoFiles)
 		pkgs, err := goutil.ParseFiles(fset, pkg.Dir, pkg.GoFiles, parser.ParseComments)
 		if err != nil {
 			return nil, "", "", fmt.Errorf("parse error: %v", err)
@@ -247,7 +247,7 @@ func GetReference(prog *Program, context string, isEmbed bool, lookup, filePath 
 		name = lookup
 	}
 
-	dbg("getReference: pkg: %#v -> name: %#v", pkg, name)
+	dbg("GetReference: pkg: %#v -> name: %#v", pkg, name)
 
 	// Already parsed this one, don't need to do it again.
 	if ref, ok := prog.References[lookup]; ok {
@@ -517,6 +517,8 @@ func resolveType(prog *Program, context string, isEmbed bool, typ *ast.Ident, fi
 				typ.Obj.Decl)
 		}
 	}
+
+	dbg("resolveType: %v %v -> %#v", pkg, typ.Name, ts.Type)
 
 	// Only need to add struct types. Stuff like "type Foo string" gets added as
 	// simply a string.

--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -202,6 +202,11 @@ func fieldToSchema(prog *Program, fName, tagName string, ref Reference, f *ast.F
 start:
 	switch typ := sw.(type) {
 
+	// Pointer type; we don't really care about this, so read over it.
+	case *ast.StarExpr:
+		sw = typ.X
+		goto start
+
 	// Interface, only useful for its description.
 	case *ast.InterfaceType:
 		if len(f.Names) == 0 {
@@ -226,12 +231,6 @@ start:
 			name = typ
 		}
 
-	// Pointer type; we don't really care about this for now, so just read over
-	// it.
-	case *ast.StarExpr:
-		sw = typ.X
-		goto start
-
 	// Simple identifiers such as "string", "int", "MyType", etc.
 	case *ast.Ident:
 		canon, err := canonicalType(ref.File, pkg, typ)
@@ -253,7 +252,7 @@ start:
 		p.Type = ""
 		name = typ
 
-	// Anonymous struct
+	// Anonymous struct.
 	case *ast.StructType:
 		p.Type = "object"
 		p.Properties = map[string]*Schema{}

--- a/main_test.go
+++ b/main_test.go
@@ -59,7 +59,7 @@ func TestOpenAPI2(t *testing.T) {
 			wd, _ := os.Getwd()
 			build.Default.GOPATH = filepath.Join(wd, "/testdata/openapi2")
 
-			prog := docparse.NewProgram(false)
+			prog := docparse.NewProgram(os.Getenv("KOMMENTAAR_DEBUG") != "")
 			prog.Config.Title = "x"
 			prog.Config.Version = "x"
 			prog.Config.Packages = []string{"./testdata/openapi2/src/" + tt.Name()}

--- a/testdata/openapi2/src/struct-anon/in.go
+++ b/testdata/openapi2/src/struct-anon/in.go
@@ -7,8 +7,12 @@ type resp struct {
 		// Name of the pipeline
 		Name  string `json:"name"`
 		NoTag int
+		Named t
 	} `json:"pipeline"`
+	Named2 t
 }
+
+type t struct{ i int }
 
 // POST /path
 //

--- a/testdata/openapi2/src/struct-anon/want.yaml
+++ b/testdata/openapi2/src/struct-anon/want.yaml
@@ -27,8 +27,15 @@ definitions:
         description: pipe it!
         type: object
         properties:
+          Named:
+            $ref: '#/definitions/struct-anon.t'
           NoTag:
             type: integer
           name:
             description: Name of the pipeline
             type: string
+  struct-anon.t:
+    type: object
+    properties:
+      i:
+        type: integer


### PR DESCRIPTION
Problem: structs that are referenced inside anonymous structs aren't
added to the prog.References map; it looks like GetReference() is never
called.