### PR TITLE
Better validation for default response from config

### DIFF
--- a/docparse/docparse_test.go
+++ b/docparse/docparse_test.go
@@ -522,3 +522,42 @@ func TestGetReference(t *testing.T) {
 		})
 	}
 }
+
+func TestParseResponse(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantCode int
+		wantResp *Response
+		wantErr  string
+	}{
+		{
+			"Response 400: $ref: net/mail.Address",
+			400,
+			&Response{ContentType: "application/json", Body: &Ref{Reference: "mail.Address"}},
+			"",
+		},
+		{
+			"Response 400 $ref: net/mail.Address",
+			0,
+			nil,
+			"",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			prog := NewProgram(false)
+			code, resp, err := ParseResponse(prog, "", tt.in)
+
+			if !test.ErrorContains(err, tt.wantErr) {
+				t.Fatalf("wrong error\nwant: %v\ngot:  %v", tt.wantErr, err)
+			}
+			if code != tt.wantCode {
+				t.Errorf("wrong code\nwant: %v\ngot:  %v", tt.wantCode, code)
+			}
+			if d := diff.Diff(tt.wantResp, resp); d != "" {
+				t.Errorf(d)
+			}
+		})
+	}
+}

--- a/kconfig/kconfig.go
+++ b/kconfig/kconfig.go
@@ -36,6 +36,9 @@ func Load(prog *docparse.Program, file string) error {
 			if err != nil {
 				return err
 			}
+			if resp == nil {
+				return fmt.Errorf("malformed default response: %q", strings.Join(line, " "))
+			}
 
 			if _, ok := prog.Config.DefaultResponse[code]; ok {
 				return fmt.Errorf("default response code %v defined more than once", code)


### PR DESCRIPTION
It'll return nil on invalid lines, and not an error (which is okay, but
we do need to handle it).