### PR TITLE
Don't store embedded structs as context

### DIFF
--- a/docparse/docparse.go
+++ b/docparse/docparse.go
@@ -142,6 +142,7 @@ type Reference struct {
 	Lookup  string  // Identifier as pkg.type.
 	Info    string  // Comment of the struct itself.
 	Context string  // Context we found it: path, query, form, req, resp.
+	IsEmbed bool    // Is an embedded struct.
 	Schema  *Schema // JSON schema.
 
 	Fields []Param // Struct fields.
@@ -399,7 +400,7 @@ func parseRefLine(prog *Program, context, line, filePath string) (*Ref, error) {
 			return nil, fmt.Errorf("invalid reference: %#v", line)
 		}
 
-		ref, err := GetReference(prog, context, strings.TrimSpace(s[1]), filePath)
+		ref, err := GetReference(prog, context, false, strings.TrimSpace(s[1]), filePath)
 		if err != nil {
 			return nil, fmt.Errorf("GetReference: %v", err)
 		}

--- a/docparse/docparse_test.go
+++ b/docparse/docparse_test.go
@@ -501,7 +501,7 @@ func TestGetReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%v", tt.in), func(t *testing.T) {
 			prog := NewProgram(false)
-			out, err := GetReference(prog, "", tt.in, ".")
+			out, err := GetReference(prog, "", false, tt.in, ".")
 			if !test.ErrorContains(err, tt.wantErr) {
 				t.Fatalf("wrong err\nout:  %v\nwant: %v\n", err, tt.wantErr)
 			}

--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -52,8 +52,8 @@ func structToSchema(prog *Program, name string, ref Reference) (*Schema, error) 
 		case "path", "query", "form":
 			name = goutil.TagName(p.KindField, ref.Context)
 		default:
-			// TODO: doesn't have to be json tag; that's just what Desk happens to
-			// use. We should get it from Content-Type or some such instead.
+			// TODO: doesn't have to be json tag; that's just what Desk happens
+			// to use. We should get it from Content-Type or some such instead.
 			name = goutil.TagName(p.KindField, "json")
 		}
 
@@ -224,7 +224,7 @@ start:
 			name = typ.Sel
 
 			lookup := pkg + "." + name.Name
-			if _, err := GetReference(prog, "", lookup, ref.File); err != nil {
+			if _, err := GetReference(prog, "", false, lookup, ref.File); err != nil {
 				return nil, fmt.Errorf("GetReference: %v", err)
 			}
 		case *ast.Ident:
@@ -441,7 +441,7 @@ arrayStart:
 	p.Items = &Schema{Reference: sRef}
 
 	// Add to prog.References.
-	_, err = GetReference(prog, "", lookup, ref.File)
+	_, err = GetReference(prog, "", false, lookup, ref.File)
 	return err
 }
 

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -146,11 +146,11 @@ func write(outFormat string, w io.Writer, prog *docparse.Program) error {
 		switch v.Context {
 		case "form", "query", "path":
 			// Nothing, this will be inline in the operation.
-		case docparse.ContextEmbed:
-			// Skip.
 		default:
-			prefixPropertyReferences(v.Schema.Properties)
-			out.Definitions[k] = *v.Schema
+			if !v.IsEmbed {
+				prefixPropertyReferences(v.Schema.Properties)
+				out.Definitions[k] = *v.Schema
+			}
 		}
 	}
 

--- a/testdata/openapi2/src/params-embed/in.go
+++ b/testdata/openapi2/src/params-embed/in.go
@@ -1,0 +1,20 @@
+package params
+
+type common struct {
+	// FieldTasks common description.
+	//
+	// {enum: name priority status description}
+	FieldTasks []string `query:"fields[tasks]"`
+}
+
+type queryRef struct {
+	common
+
+	// Size of page {default: 10, range: 10-100, required}.
+	PageSize int64 `query:"pageSize"`
+}
+
+// GET /path
+//
+// Query: $ref: queryRef
+// Response 200: $empty

--- a/testdata/openapi2/src/params-embed/want.yaml
+++ b/testdata/openapi2/src/params-embed/want.yaml
@@ -1,0 +1,38 @@
+swagger: "2.0"
+info:
+  title: x
+  version: x
+consumes:
+- application/json
+produces:
+- application/json
+paths:
+  /path:
+    get:
+      operationId: GET_path
+      produces:
+      - application/json
+      parameters:
+      - name: pageSize
+        in: query
+        description: Size of page.
+        type: integer
+        required: true
+        default: "10"
+        minimum: 10
+        maximum: 100
+      - name: fields[tasks]
+        in: query
+        description: FieldTasks common description.
+        type: array
+        items:
+          type: string
+        enum:
+        - name
+        - priority
+        - status
+        - description
+      responses:
+        200:
+          description: 200 OK
+definitions: {}


### PR DESCRIPTION
The Context parameter was used both to signal the location we found the
struct (e.g. response, query params, etc.) and whether or not it's an
embedded struct (which needs to be treated different).

The problem with this is that context information is lost when using
embedded structs in e.g. query params, leading to subtle problems such
as using the wrong struct tags.

This fixes that by adding an IsEmbed parameter.

Fixes #36