### PR TITLE
Add $data keyword

### DIFF
--- a/doc/syntax.markdown
+++ b/doc/syntax.markdown
@@ -207,6 +207,12 @@ without any code. In general this should only be used for `204 No Content`:
 
     Response 204: $empty
 
+The `$data` keyword indicates that this response returns unstructured data, such
+as text, HTML, an image, spreadsheet document, etc. An explicit Content-Type is
+required when using `$data`.
+
+    Response 200 (text/plain): $data
+
 The `$default` keyword indicates it should use the default reference for this
 response code:
 

--- a/docparse/docparse_test.go
+++ b/docparse/docparse_test.go
@@ -12,7 +12,7 @@ import (
 func TestParseComments(t *testing.T) {
 	stdResp := map[int]Response{200: Response{
 		ContentType: "application/json",
-		Body:        &Ref{Description: "OK (no data)"},
+		Body:        &Ref{Description: "200 OK (no data)"},
 	}}
 
 	tests := []struct {
@@ -256,11 +256,11 @@ Response 400 (w00t): $empty
 				Responses: map[int]Response{
 					200: {
 						ContentType: "application/json",
-						Body:        &Ref{Description: "OK (no data)"},
+						Body:        &Ref{Description: "200 OK (no data)"},
 					},
 					400: {
 						ContentType: "w00t",
-						Body:        &Ref{Description: "Bad Request (no data)"},
+						Body:        &Ref{Description: "400 Bad Request (no data)"},
 					},
 				},
 			}},
@@ -535,7 +535,7 @@ func TestParseResponse(t *testing.T) {
 			400,
 			&Response{
 				ContentType: "application/json",
-				Body:        &Ref{Reference: "mail.Address", Description: "Bad Request"},
+				Body:        &Ref{Reference: "mail.Address", Description: "400 Bad Request"},
 			},
 			"",
 		},

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"sort"
 	"strings"
 
@@ -286,7 +285,7 @@ func write(outFormat string, w io.Writer, prog *docparse.Program) error {
 
 		for code, resp := range e.Responses {
 			r := Response{
-				Description: fmt.Sprintf("%v %v", code, http.StatusText(code)),
+				Description: resp.Body.Description,
 			}
 
 			// Link reference.

--- a/testdata/openapi2/src/blank-line/want.json
+++ b/testdata/openapi2/src/blank-line/want.json
@@ -26,7 +26,7 @@
         ],
         "responses": {
           "200": {
-            "description": "200 OK"
+            "description": "200 OK (no data)"
           }
         }
       }

--- a/testdata/openapi2/src/invalid-resp-data-no-ct/in.go
+++ b/testdata/openapi2/src/invalid-resp-data-no-ct/in.go
@@ -1,0 +1,6 @@
+package req
+
+// POST /path
+//
+// Response 200: $data
+// Response 400: $empty

--- a/testdata/openapi2/src/invalid-resp-data-no-ct/wantErr
+++ b/testdata/openapi2/src/invalid-resp-data-no-ct/wantErr
@@ -1,0 +1,1 @@
+explicit Content-Type required for $data

--- a/testdata/openapi2/src/multiple-routes/want.yaml
+++ b/testdata/openapi2/src/multiple-routes/want.yaml
@@ -31,7 +31,7 @@ paths:
         type: string
       responses:
         200:
-          description: 200 OK
+          description: 200 OK (no data)
   /foo:
     get:
       operationId: GET_foo
@@ -56,7 +56,7 @@ paths:
         type: string
       responses:
         200:
-          description: 200 OK
+          description: 200 OK (no data)
   /path/{id}:
     post:
       operationId: POST_path_{id}
@@ -81,5 +81,5 @@ paths:
         type: string
       responses:
         200:
-          description: 200 OK
+          description: 200 OK (no data)
 definitions: {}

--- a/testdata/openapi2/src/params-embed/want.yaml
+++ b/testdata/openapi2/src/params-embed/want.yaml
@@ -34,5 +34,5 @@ paths:
         - description
       responses:
         200:
-          description: 200 OK
+          description: 200 OK (no data)
 definitions: {}

--- a/testdata/openapi2/src/params/want.yaml
+++ b/testdata/openapi2/src/params/want.yaml
@@ -29,5 +29,5 @@ paths:
         type: string
       responses:
         200:
-          description: 200 OK
+          description: 200 OK (no data)
 definitions: {}

--- a/testdata/openapi2/src/path-fields/want.yaml
+++ b/testdata/openapi2/src/path-fields/want.yaml
@@ -25,5 +25,5 @@ paths:
         required: true
       responses:
         200:
-          description: 200 OK
+          description: 200 OK (no data)
 definitions: {}

--- a/testdata/openapi2/src/path-generated/want.yaml
+++ b/testdata/openapi2/src/path-generated/want.yaml
@@ -25,5 +25,5 @@ paths:
         required: true
       responses:
         200:
-          description: 200 OK
+          description: 200 OK (no data)
 definitions: {}

--- a/testdata/openapi2/src/req-ct/want.yaml
+++ b/testdata/openapi2/src/req-ct/want.yaml
@@ -22,7 +22,7 @@ paths:
           $ref: '#/definitions/req-ct.reqRef'
       responses:
         200:
-          description: 200 OK
+          description: 200 OK (no data)
 definitions:
   req-ct.reqRef:
     title: reqRef

--- a/testdata/openapi2/src/req/want.yaml
+++ b/testdata/openapi2/src/req/want.yaml
@@ -22,7 +22,7 @@ paths:
           $ref: '#/definitions/req.reqRef'
       responses:
         200:
-          description: 200 OK
+          description: 200 OK (no data)
 definitions:
   req.reqRef:
     title: reqRef

--- a/testdata/openapi2/src/resp-data/in.go
+++ b/testdata/openapi2/src/resp-data/in.go
@@ -1,0 +1,6 @@
+package req
+
+// POST /path
+//
+// Response 200 (text/plain): $data
+// Response 400: $empty

--- a/testdata/openapi2/src/resp-data/want.yaml
+++ b/testdata/openapi2/src/resp-data/want.yaml
@@ -10,13 +10,12 @@ paths:
   /path:
     post:
       operationId: POST_path
-      tags:
-      - tag
-      consumes:
-      - application/x-www-form-urlencoded
       produces:
+      - text/plain
       - application/json
       responses:
         200:
-          description: 200 OK (no data)
+          description: 200 OK (text/plain data)
+        400:
+          description: 400 Bad Request (no data)
 definitions: {}

--- a/testdata/openapi2/src/struct-required/want.yaml
+++ b/testdata/openapi2/src/struct-required/want.yaml
@@ -24,5 +24,5 @@ paths:
         required: true
       responses:
         200:
-          description: 200 OK
+          description: 200 OK (no data)
 definitions: {}

--- a/testdata/openapi2/src/type-block/want.yaml
+++ b/testdata/openapi2/src/type-block/want.yaml
@@ -22,7 +22,7 @@ paths:
           $ref: '#/definitions/type-block.reqRef'
       responses:
         200:
-          description: 200 OK
+          description: 200 OK (no data)
 definitions:
   type-block.reqRef:
     title: reqRef


### PR DESCRIPTION
Previously there was no good way to describe non-structured return data
such as:

	// Response 200 (application/vnd.openxmlformats-officedocument.spreadsheetml.sheet): $empty
	// Response 200 (text/plain): $empty
	// Response 200 (image/jpeg): $empty

This adds a new $data keyword, which works the same as the $empty
keyword:

	// Response 200 (application/vnd.openxmlformats-officedocument.spreadsheetml.sheet): $data
	// Response 200 (text/plain): $data
	// Response 200 (image/jpeg): $data

The difference is in the generated output:

        200:
          description: 200 OK (no data)

vs:

        200:
          description: 200 OK (text/plain data)

The OpenAPI2 format provides no method for detailing which response code
returns which Content-Type, which is why it's in the description. This i
s fixed with the OpenAPI3 spec, but we can't use that because of the
Stoplight.io tool :-(

Fixes #41