### PR TITLE
Ignore unexported fields and error on unexported fields with a tag

### DIFF
--- a/doc/syntax.markdown
+++ b/doc/syntax.markdown
@@ -127,6 +127,10 @@ Only `struct` and `interface` types can be referenced. Interfaces don't have
 fields and only the documentation for the interface will be added to the
 output.
 
+Embedded structs are merged in to the parent struct, unless they have the
+applicable struct tag (as configured with `struct-tag`), in which case they're
+added as reference in the output.
+
 References are looked up in the customary locations (vendor, GOPATH). Invalid
 references are an error.
 
@@ -134,6 +138,9 @@ references are an error.
     ; https://golang.org/ref/spec#Qualified_identifiers
     ; https://golang.org/ref/spec#Import_declarations
     ref            = identifier / QualifiedIdent / ( ImportPath "." identifier )
+
+Unexported fields are ignored; unexported fields with an applicable struct tag
+are considered an error.
 
 ### Path, Query, and Form references
 
@@ -224,14 +231,6 @@ It is an error if no default reference is configured for this response code.
 
 References
 ----------
-
-Any struct or interface can be referenced.
-
-Anonymous structs are merged in to the parent struct.
-
-Embedded structs are merged in to the parent struct, unless they have the
-applicable struct tag (as configured with `struct-tag`), in which case they're
-added as reference in the output.
 
 ### Parameter properties
 

--- a/docparse/find_test.go
+++ b/docparse/find_test.go
@@ -14,6 +14,7 @@ import (
 func TestExampleDir(t *testing.T) {
 	prog := NewProgram(false)
 	prog.Config.Packages = []string{"../example"}
+	prog.Config.StructTag = "json"
 	prog.Config.Output = func(_ io.Writer, p *Program) error {
 		if len(p.Endpoints) < 2 {
 			t.Errorf("len(p.Endpoints) == %v", len(p.Endpoints))

--- a/testdata/openapi2/src/export/in.go
+++ b/testdata/openapi2/src/export/in.go
@@ -1,0 +1,17 @@
+package req
+
+type ref struct {
+	Exported    string `query:"exported"`
+	notExported string
+}
+
+type ref2 struct {
+	Exported    string `json:"exported"`
+	notExported string
+}
+
+// POST /path
+//
+// Query: $ref: ref
+// Request body: $ref: ref2
+// Response 200: $empty

--- a/testdata/openapi2/src/export/want.yaml
+++ b/testdata/openapi2/src/export/want.yaml
@@ -1,0 +1,35 @@
+swagger: "2.0"
+info:
+  title: x
+  version: x
+consumes:
+- application/json
+produces:
+- application/json
+paths:
+  /path:
+    post:
+      operationId: POST_path
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - name: exported
+        in: query
+        type: string
+      - name: export.ref2
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/export.ref2'
+      responses:
+        200:
+          description: 200 OK (no data)
+definitions:
+  export.ref2:
+    title: ref2
+    type: object
+    properties:
+      exported:
+        type: string

--- a/testdata/openapi2/src/invalid-unexported/in.go
+++ b/testdata/openapi2/src/invalid-unexported/in.go
@@ -1,0 +1,11 @@
+package req
+
+type ref struct {
+	Exported    string `query:"exported"`
+	notExported string `query:"not"`
+}
+
+// POST /path
+//
+// Query: $ref: ref
+// Response 200: $empty

--- a/testdata/openapi2/src/invalid-unexported/wantErr
+++ b/testdata/openapi2/src/invalid-unexported/wantErr
@@ -1,0 +1,1 @@
+not exported but has "query" tag: invalid-unexported.ref field [notExported]

--- a/testdata/openapi2/src/multiple-routes/in.go
+++ b/testdata/openapi2/src/multiple-routes/in.go
@@ -1,8 +1,14 @@
 package params
 
-type pathRef struct{ id string }
-type queryRef struct{ id string }
-type formRef struct{ id string }
+type pathRef struct {
+	ID string `path:"id"`
+}
+type queryRef struct {
+	ID string `query:"id"`
+}
+type formRef struct {
+	ID string `form:"id"`
+}
 
 // POST /path/{id} tag
 // GET /foo tag

--- a/testdata/openapi2/src/params/in.go
+++ b/testdata/openapi2/src/params/in.go
@@ -1,8 +1,14 @@
 package params
 
-type pathRef struct{ id string }
-type queryRef struct{ id string }
-type formRef struct{ id string }
+type pathRef struct {
+	ID string `path:"id"`
+}
+type queryRef struct {
+	ID string `query:"id"`
+}
+type formRef struct {
+	ID string `form:"id"`
+}
 
 // POST /path/{id} tag
 //

--- a/testdata/openapi2/src/struct-slice/in.go
+++ b/testdata/openapi2/src/struct-slice/in.go
@@ -5,7 +5,7 @@ type resp struct {
 	Custom    mySlice           `json:"custom"`    // Custom comment.
 	Double    anotherSlice      `json:"another"`   // Double comment.
 	StructRef customFieldValues `json:"structRef"` // structRefComment.
-	deal      deal
+	Deal      deal              `json:"deal"`
 }
 
 // mySlice comment.
@@ -17,11 +17,11 @@ type anotherSlice mySlice
 type customFieldValues []*customFieldValue
 
 type customFieldValue struct {
-	val string
+	Val string `json:"val"`
 }
 
 type deal struct {
-	customFieldValues []*customFieldValue
+	CustomFieldValues []*customFieldValue
 }
 
 // POST /path

--- a/testdata/openapi2/src/struct-slice/want.yaml
+++ b/testdata/openapi2/src/struct-slice/want.yaml
@@ -28,7 +28,7 @@ definitions:
     title: deal
     type: object
     properties:
-      customFieldValues:
+      CustomFieldValues:
         type: array
         items:
           $ref: '#/definitions/struct-slice.customFieldValue'


### PR DESCRIPTION
Unexported fields usually can't be marshalled/unmarshalled, and adding
them to the output isn't useful.

When an unexported field has a `json`, `path`, etc. tag then this is
usually an error. `go vet` already reports this for `json` tags. Also
implement this check in Kommentaar.