### PR TITLE
Fix intermittent test failures

### DIFF
--- a/docparse/docparse.go
+++ b/docparse/docparse.go
@@ -63,6 +63,10 @@ type DefaultResponse struct {
 func NewProgram(dbg bool) *Program {
 	printDebug = dbg
 
+	// Clear cache; otherwise tests with -count 2 fail.
+	// TODO: figure out why; should work really.
+	declsCache = make(map[string][]declCache)
+
 	return &Program{
 		References: make(map[string]Reference),
 		Config: Config{

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"go/build"
 	"io/ioutil"
 	"os"
@@ -16,19 +17,15 @@ import (
 )
 
 // Just basic sanity test to make sure it doesn't error out or something.
-func TestMain(t *testing.T) {
-	saveout := os.Stdout
-	saveerr := os.Stderr
-	_, stdout, _ := os.Pipe()
-	_, stderr, _ := os.Pipe()
-	os.Stdout = stdout
-	os.Stderr = stderr
-
+func TestStart(t *testing.T) {
 	os.Args = []string{"", "-config", "config.example", "./example/..."}
-	main()
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
-	os.Stdout = saveout
-	os.Stderr = saveerr
+	stdout = bytes.NewBufferString("")
+	_, err := start()
+	if err != nil {
+		t.Error(err)
+	}
 }
 
 func TestOpenAPI2(t *testing.T) {

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -309,6 +309,8 @@ func write(outFormat string, w io.Writer, prog *docparse.Program) error {
 			op.Produces = appendIfNotExists(op.Produces, resp.ContentType)
 		}
 
+		sort.Strings(op.Produces)
+
 		if out.Paths[e.Path] == nil {
 			out.Paths[e.Path] = &Path{}
 		}

--- a/testdata/openapi2/src/resp-data/want.yaml
+++ b/testdata/openapi2/src/resp-data/want.yaml
@@ -11,8 +11,8 @@ paths:
     post:
       operationId: POST_path
       produces:
-      - text/plain
       - application/json
+      - text/plain
       responses:
         200:
           description: 200 OK (text/plain data)


### PR DESCRIPTION
Produces order wasn't stable, so sort that.

Also attempt to fix `go test -count 2 ./..`, but that seems hard. For
some reason package names get added with a different name:

            -  Package: (string) (len=39) "github.com/teamwork/kommentaar/docparse",
            +  Package: (string) (len=8) "docparse",

Why isn't that the full package name? Can't figure it out, so leave it
for now.