### PR TITLE
Add {omitdoc} parameter property

### DIFF
--- a/doc/syntax.markdown
+++ b/doc/syntax.markdown
@@ -247,6 +247,7 @@ special fields in the output format.
 
 Supported parameters:
 
+- `omitdoc`         – parameter is not added to the generated output.
 - `required`        – parameter must be given.
 - `optional`        – parameter can be blank; this is the default, but
                       specifying it explicitly may be useful in some cases.

--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -33,6 +33,8 @@ type Schema struct {
 
 	// Store structs.
 	Properties map[string]*Schema `json:"properties,omitempty" yaml:"properties,omitempty"`
+
+	OmitDoc bool `json:"-" yaml:"-"`
 }
 
 // Convert a struct to a JSON schema.
@@ -92,12 +94,15 @@ const (
 	paramOptional  = "optional"
 	paramOmitEmpty = "omitempty"
 	paramReadOnly  = "readonly"
+	paramOmitDoc   = "omitdoc"
 )
 
 func setTags(name string, p *Schema, tags []string) error {
 	for _, t := range tags {
 		switch t {
 
+		case paramOmitDoc:
+			p.OmitDoc = true
 		case paramRequired:
 			p.Required = append(p.Required, name)
 		case paramOptional:

--- a/testdata/openapi2/src/struct-omitdoc/in.go
+++ b/testdata/openapi2/src/struct-omitdoc/in.go
@@ -1,0 +1,33 @@
+package path
+
+type pathRef struct {
+	ID        int64 `path:"id"`
+	CompanyID int64 `path:"companyID"` // Hello there {omitdoc}
+}
+type queryRef struct {
+	ID        int64 `query:"id"`
+	CompanyID int64 `query:"companyID"` // Hello there {omitdoc}
+}
+
+type formRef struct {
+	ID        int64 `form:"id"`
+	CompanyID int64 `form:"companyID"` // Hello there {omitdoc}
+}
+
+type req struct {
+	ID        int64 `json:"id"`
+	CompanyID int64 `json:"companyID"` // Hello there {omitdoc}
+}
+
+type resp struct {
+	ID        int64 `json:"id"`
+	CompanyID int64 `json:"companyID"` // Hello there {omitdoc}
+}
+
+// POST /path/{companyID}/{id}
+//
+// Path:         $ref: pathRef
+// Query:        $ref: queryRef
+// Form:         $ref: formRef
+// Request body: $ref: req
+// Response 200: $ref: resp

--- a/testdata/openapi2/src/struct-omitdoc/want.yaml
+++ b/testdata/openapi2/src/struct-omitdoc/want.yaml
@@ -1,0 +1,55 @@
+swagger: "2.0"
+info:
+  title: x
+  version: x
+consumes:
+- application/json
+produces:
+- application/json
+paths:
+  /path/{companyID}/{id}:
+    post:
+      operationId: POST_path_{companyID}_{id}
+      consumes:
+      - application/x-www-form-urlencoded
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - name: struct-omitdoc.req
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/struct-omitdoc.req'
+      - name: id
+        in: path
+        type: integer
+        required: true
+      - name: id
+        in: query
+        type: integer
+      - name: id
+        in: formData
+        type: integer
+      - name: companyID
+        in: path
+        type: integer
+        required: true
+      responses:
+        200:
+          description: 200 OK
+          schema:
+            $ref: '#/definitions/struct-omitdoc.resp'
+definitions:
+  struct-omitdoc.req:
+    title: req
+    type: object
+    properties:
+      id:
+        type: integer
+  struct-omitdoc.resp:
+    title: resp
+    type: object
+    properties:
+      id:
+        type: integer


### PR DESCRIPTION
Add the {omitdoc} property, so that some struct fields can be omitted
from the generated OpenAPI document.

I decided on {omitdoc}, as "omit" is fairly common in Go, but just
{omit} and {-} is perhaps a but too obscure.