### PR TITLE
Add variable expanding support to description

### DIFF
--- a/doc/syntax.markdown
+++ b/doc/syntax.markdown
@@ -92,6 +92,11 @@ description. This is free-form text and may contain blank lines. It may be
 omitted – especially in cases where it just repeats the tagline it's not useful
 to add.
 
+Inside the description section the `$print` operator is also supported to allow
+referencing a constant or variable in the codebase to be added to the
+documentation. This can allow you for example to avoid duplicating some common
+text or output the value of a whitelist without duplicating it.
+
 The description will end once the first reference directive is found. The
 description cannot continue after reference directives.
 
@@ -110,6 +115,11 @@ Full example:
     later on.
 
     Adding a steering wheel or seat can be done in the PATCH request.
+
+    You can side-load addition data to save an extra request, the following
+    relationships are available for side-loading with the include query
+    paramter:
+    $print postBikeIncludes
 
 Reference directives
 --------------------

--- a/doc/syntax.markdown
+++ b/doc/syntax.markdown
@@ -78,7 +78,7 @@ follows (and will be ignored if it doesn't):
 
 Multiple path descriptions are allowed:
 
-    VERB /path [tag]
+    VERB  /path [tag]
     OTHER /anotherpath [tag]
 
 The line immediately following the path descriptions is used as a "tagline".
@@ -92,18 +92,19 @@ description. This is free-form text and may contain blank lines. It may be
 omitted – especially in cases where it just repeats the tagline it's not useful
 to add.
 
-Inside the description section the `$print` operator is also supported to allow
-referencing a constant or variable in the codebase to be added to the
-documentation. This can allow you for example to avoid duplicating some common
-text or output the value of a whitelist without duplicating it.
+Variables can be referenced as `$varname` inside the description, which is
+useful to reference a variable or constant without duplicating it. The syntax
+for this is identical to references described in *Reference directives* (`$t`,
+`$pkg.t`, or `$import/path.t`).
 
 The description will end once the first reference directive is found. The
 description cannot continue after reference directives.
 
-    path-description   = verb path [ tag *( " " tag ) ] LF
-    verb               = "GET" / "HEAD" / "POST" / "PUT" / "PATCH" / "DELETE" / "CONNECT" / "OPTIONS" / "TRACE"
-    path               = path-absolute  ; https://tools.ietf.org/html/rfc3986#section-3.3
-    tag                = *(ALPHA / DIGIT)
+    path-description    = verb path [ tag *( " " tag ) ] LF
+    verb                = "GET" / "HEAD" / "POST" / "PUT" / "PATCH" / "DELETE" / "CONNECT" / "OPTIONS" / "TRACE"
+    path                = path-absolute  ; https://tools.ietf.org/html/rfc3986#section-3.3
+    tag                 = *(ALPHA / DIGIT)
+    description-ref     = "$" 1*ref
 
 Full example:
 
@@ -116,10 +117,7 @@ Full example:
 
     Adding a steering wheel or seat can be done in the PATCH request.
 
-    You can side-load addition data to save an extra request, the following
-    relationships are available for side-loading with the include query
-    paramter:
-    $print postBikeIncludes
+    The default colour is $defaultColor.
 
 Reference directives
 --------------------

--- a/docparse/docparse.go
+++ b/docparse/docparse.go
@@ -325,11 +325,30 @@ func parseComment(prog *Program, comment, pkgPath, filePath string) ([]*Endpoint
 		e.Info += line + "\n"
 	}
 
-	e.Info = strings.TrimSpace(e.Info)
-
 	if len(e.Responses) == 0 {
 		return nil, 0, fmt.Errorf("%v: must have at least one response", e.Path)
 	}
+
+	var printErr error
+	e.Info = regexp.MustCompile(`\$print [a-zA-Z0-9\.]+`).
+		ReplaceAllStringFunc(e.Info, func(m string) string {
+			lookup := m[7:] // strip "$print "
+			name, pkg := parseLookup(lookup, filePath)
+			vs, _, _, err := findValue(filePath, pkg, name)
+			if err != nil {
+				printErr = fmt.Errorf("%s: findValue: %v", m, err)
+				return ""
+			}
+
+			if len(vs.Values) == 0 {
+				return ""
+			}
+			return exprToString(vs.Values[0])
+		})
+	if printErr != nil {
+		return nil, 0, printErr
+	}
+	e.Info = strings.TrimSpace(e.Info)
 
 	r := make([]*Endpoint, len(aliases)+1)
 	r[0] = e
@@ -530,4 +549,29 @@ func MapType(prog *Program, in string) (kind, format string) {
 	}
 
 	return kind, format
+}
+
+func exprToString(node ast.Expr) string {
+	switch n := node.(type) {
+	case *ast.BasicLit:
+		if n.Kind == token.STRING {
+			unquoted, _ := strconv.Unquote(n.Value)
+			return unquoted
+		}
+		return n.Value
+	case *ast.KeyValueExpr:
+		return exprToString(n.Key) + ": " + exprToString(n.Value)
+	case *ast.CompositeLit:
+		switch n.Type.(type) {
+		case *ast.ArrayType, *ast.MapType:
+			var v string
+			for _, e := range n.Elts {
+				v += "- " + exprToString(e) + "\n"
+			}
+			return v[:len(v)-1]
+		}
+	case *ast.Ident:
+		return n.Name
+	}
+	return ""
 }

--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go/ast"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -531,16 +530,7 @@ func JSONSchemaType(t string) string {
 
 func getTypeInfo(prog *Program, lookup, filePath string) (string, error) {
 	dbg("getTypeInfo: %#v in %#v", lookup, filePath)
-	var name, pkg string
-	if c := strings.LastIndex(lookup, "."); c > -1 {
-		// imported path: models.Foo
-		pkg = lookup[:c]
-		name = lookup[c+1:]
-	} else {
-		// Current package: Foo
-		pkg = path.Dir(filePath)
-		name = lookup
-	}
+	name, pkg := parseLookup(lookup, filePath)
 
 	// Find type.
 	ts, _, _, err := findType(filePath, pkg, name)

--- a/testdata/openapi2/src/description-print-var/in.go
+++ b/testdata/openapi2/src/description-print-var/in.go
@@ -1,0 +1,45 @@
+package path
+
+import "description-print-var/otherpkg"
+
+var _ = otherpkg.DocRatelimitHeader
+
+const (
+	str       = "value of constant string"
+	ratelimit = 500
+)
+
+var (
+	strs = []string{"value", "of", "str", "slice"}
+	ints = []int{1, 2, 3, 4}
+	kv   = map[string]string{
+		"a": "b",
+		"c": "d",
+	}
+	kv2 = map[string]interface{}{
+		"int":   1,
+		"bool":  true,
+		"false": false,
+		"str":   "hello",
+		"f":     1.234,
+	}
+)
+
+// POST /path
+//
+// $print otherpkg.DocRatelimitHeader
+// $print ratelimit
+//
+// string:
+// $print str
+//
+// []string:
+// $print strs
+//
+// map[string]string:
+// $print kv
+//
+// map[string]interface{}:
+// $print kv2
+//
+// Response 200: {empty}

--- a/testdata/openapi2/src/description-print-var/in.go
+++ b/testdata/openapi2/src/description-print-var/in.go
@@ -27,19 +27,21 @@ var (
 
 // POST /path
 //
-// $print otherpkg.DocRatelimitHeader
-// $print ratelimit
+// $otherpkg.DocRatelimitHeader
+// $ratelimit
 //
 // string:
-// $print str
+// $str
 //
 // []string:
-// $print strs
+// $strs
 //
 // map[string]string:
-// $print kv
+// $kv
 //
 // map[string]interface{}:
-// $print kv2
+// $kv2
+//
+// I'm escaped \$foo
 //
 // Response 200: {empty}

--- a/testdata/openapi2/src/description-print-var/otherpkg/in.go
+++ b/testdata/openapi2/src/description-print-var/otherpkg/in.go
@@ -1,0 +1,6 @@
+package otherpkg
+
+const DocRatelimitHeader = `Rate limit is
+blah
+blah
+blah`

--- a/testdata/openapi2/src/description-print-var/want.yaml
+++ b/testdata/openapi2/src/description-print-var/want.yaml
@@ -1,0 +1,44 @@
+swagger: "2.0"
+info:
+  title: x
+  version: x
+consumes:
+- application/json
+produces:
+- application/json
+paths:
+  /path:
+    post:
+      operationId: POST_path
+      description: |-
+        Rate limit is
+        blah
+        blah
+        blah
+        500
+
+        string:
+        value of constant string
+
+        []string:
+        - value
+        - of
+        - str
+        - slice
+
+        map[string]string:
+        - a: b
+        - c: d
+
+        map[string]interface{}:
+        - int: 1
+        - bool: true
+        - false: false
+        - str: hello
+        - f: 1.234
+      produces:
+      - application/json
+      responses:
+        200:
+          description: 200 OK (no data)
+definitions: {}

--- a/testdata/openapi2/src/description-print-var/want.yaml
+++ b/testdata/openapi2/src/description-print-var/want.yaml
@@ -36,6 +36,8 @@ paths:
         - false: false
         - str: hello
         - f: 1.234
+
+        I'm escaped $foo
       produces:
       - application/json
       responses:


### PR DESCRIPTION
Here is an example from our codebase:
```go
// GET /deals.json deals
// List all deals.
//
// Returns a list of deals, they are returned with the most recently created
// first by default.
//
//
// $docIncludeHeader
// $dealIndexAllowedFilters
//
// $docFilterHeader
// $dealIndexIncludes
//
// Response 200: dealsResponse
// Response 304: {empty}
// Response 404: {default}
```

With this change I can avoid duplicating the whitelist of filters & includes, and I can also add some preamble text above it with the `docIncludeHeader` and filter constants I've made.

See the added `description-print-var` test for a full example.

----

It modifies the `findType` function extracting out the shared logic to `getDecls` and some other functions. Then adds a `findValue` function to lookup values (consts,vars). I opted to add a new function specifically for values since everything else operates on `*ast.TypeSpec` the only one uses `*ast.ValueSpec` is the modified `parseComment` function to expand the `$print lines`.

--

Edit:

Updated to match the commit by Martin to change to use `$foo` rather than `$print foo` also rebased on master