### PR TITLE
Fix mapping for same package and update tests

### DIFF
--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -255,7 +255,15 @@ start:
 			goto start
 		}
 
-		p.Type = JSONSchemaType(typ.Name)
+		mappedType, mappedFormat := MapType(prog, pkg+"."+typ.Name)
+		if mappedType != "" {
+			p.Type = JSONSchemaType(mappedType)
+		} else {
+			p.Type = JSONSchemaType(typ.Name)
+		}
+		if mappedFormat != "" {
+			p.Format = mappedFormat
+		}
 
 		// e.g. string, int64, etc.: don't need to look up.
 		if isPrimitive(p.Type) {

--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -246,16 +246,18 @@ start:
 
 	// Simple identifiers such as "string", "int", "MyType", etc.
 	case *ast.Ident:
-		canon, err := canonicalType(ref.File, pkg, typ)
-		if err != nil {
-			return nil, fmt.Errorf("cannot get canonical type: %v", err)
-		}
-		if canon != nil {
-			sw = canon
-			goto start
-		}
-
 		mappedType, mappedFormat := MapType(prog, pkg+"."+typ.Name)
+		if mappedType == "" {
+			// Only check for canonicalType if this isn't mapped.
+			canon, err := canonicalType(ref.File, pkg, typ)
+			if err != nil {
+				return nil, fmt.Errorf("cannot get canonical type: %v", err)
+			}
+			if canon != nil {
+				sw = canon
+				goto start
+			}
+		}
 		if mappedType != "" {
 			p.Type = JSONSchemaType(mappedType)
 		} else {
@@ -297,17 +299,19 @@ start:
 		pkg = pkgSel.Name
 		name = typ.Sel
 
-		canon, err := canonicalType(ref.File, pkgSel.Name, typ.Sel)
-		if err != nil {
-			return nil, fmt.Errorf("cannot get canonical type: %v", err)
-		}
-		if canon != nil {
-			sw = canon
-			goto start
-		}
-
 		lookup := pkg + "." + name.Name
 		t, f := MapType(prog, lookup)
+		if t == "" {
+			// Only check for canonicalType if this isn't mapped.
+			canon, err := canonicalType(ref.File, pkgSel.Name, typ.Sel)
+			if err != nil {
+				return nil, fmt.Errorf("cannot get canonical type: %v", err)
+			}
+			if canon != nil {
+				sw = canon
+				goto start
+			}
+		}
 
 		p.Format = f
 		if t != "" {

--- a/testdata/openapi2/src/struct-mapping/in.go
+++ b/testdata/openapi2/src/struct-mapping/in.go
@@ -7,7 +7,11 @@ type a struct {
 	Foos           otherpkg.Foos  `json:"foos"`
 	Time           otherpkg.Time  `json:"time"`
 	NullableString NullableString `json:"nullableString"`
+	State          otherpkg.State `json:"state"`
+	StringyInt     StringyInt     `json:"stringyInt"`
 }
+
+type StringyInt int
 
 type NullableString struct {
 }

--- a/testdata/openapi2/src/struct-mapping/in.go
+++ b/testdata/openapi2/src/struct-mapping/in.go
@@ -1,0 +1,18 @@
+package path
+
+import "struct-mapping/otherpkg"
+
+type a struct {
+	Foo            otherpkg.Foo   `json:"foo"`
+	Foos           otherpkg.Foos  `json:"foos"`
+	Time           otherpkg.Time  `json:"time"`
+	NullableString NullableString `json:"nullableString"`
+}
+
+type NullableString struct {
+}
+
+// POST /path
+//
+// Request body: $ref: a
+// Response 200: $ref: a

--- a/testdata/openapi2/src/struct-mapping/otherpkg/in.go
+++ b/testdata/openapi2/src/struct-mapping/otherpkg/in.go
@@ -1,0 +1,10 @@
+package otherpkg
+
+type Foo struct {
+	Bar string
+}
+
+type Foos []*Foo
+
+type Time struct {
+}

--- a/testdata/openapi2/src/struct-mapping/otherpkg/in.go
+++ b/testdata/openapi2/src/struct-mapping/otherpkg/in.go
@@ -8,3 +8,5 @@ type Foos []*Foo
 
 type Time struct {
 }
+
+type State int

--- a/testdata/openapi2/src/struct-mapping/test.conf
+++ b/testdata/openapi2/src/struct-mapping/test.conf
@@ -1,0 +1,19 @@
+# map-format
+#         otherpkg.Foos object
+#         otherpkg.Time date-time
+#         map-format.NullableString string
+
+# Map types to anoter type. Useful for wrappers around types that don't need to
+# be exposed in the user-facing documentation.
+#
+# The map target must be a Go built-in type (string, int64, etc.)
+map-types
+        otherpkg.Time string
+        struct-mapping.NullableString string
+
+# Map some times to an OpenAPI format.
+#
+# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#dataTypeFormat
+# https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3
+map-format
+        otherpkg.Time date-time

--- a/testdata/openapi2/src/struct-mapping/test.conf
+++ b/testdata/openapi2/src/struct-mapping/test.conf
@@ -10,6 +10,8 @@
 map-types
         otherpkg.Time string
         struct-mapping.NullableString string
+        otherpkg.State string
+        struct-mapping.StringyInt string
 
 # Map some times to an OpenAPI format.
 #

--- a/testdata/openapi2/src/struct-mapping/want.yaml
+++ b/testdata/openapi2/src/struct-mapping/want.yaml
@@ -44,6 +44,10 @@ definitions:
           $ref: '#/definitions/otherpkg.Foo'
       nullableString:
         type: string
+      state:
+        type: string
+      stringyInt:
+        type: string
       time:
         type: string
         format: date-time

--- a/testdata/openapi2/src/struct-mapping/want.yaml
+++ b/testdata/openapi2/src/struct-mapping/want.yaml
@@ -1,0 +1,49 @@
+swagger: "2.0"
+info:
+  title: x
+  version: x
+consumes:
+- application/json
+produces:
+- application/json
+paths:
+  /path:
+    post:
+      operationId: POST_path
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - name: struct-mapping.a
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/struct-mapping.a'
+      responses:
+        200:
+          description: 200 OK
+          schema:
+            $ref: '#/definitions/struct-mapping.a'
+definitions:
+  otherpkg.Foo:
+    title: Foo
+    type: object
+    properties:
+      Bar:
+        type: string
+  struct-mapping.a:
+    title: a
+    type: object
+    properties:
+      foo:
+        $ref: '#/definitions/otherpkg.Foo'
+      foos:
+        type: array
+        items:
+          $ref: '#/definitions/otherpkg.Foo'
+      nullableString:
+        type: string
+      time:
+        type: string
+        format: date-time


### PR DESCRIPTION
- Updates the tests so you can now pass a config
- Adds more testing around mapping
- Fixes issue where `Ident` wasn't mapped
- Checks mapping instead of resolving to its base type with canonical type function

I made these changes in preparation to add something to the mapping, turns out it wasn't a great place to add the feature but these changes are still useful.