### PR TITLE
Give endpoints a tag when outputting to html to avoid panic

### DIFF
--- a/html/html.go
+++ b/html/html.go
@@ -321,6 +321,12 @@ func ServeHTML(addr string) func(io.Writer, *docparse.Program) error {
 				return
 			}
 
+			for _, e := range prog.Endpoints {
+				if len(e.Tags) == 0 {
+					e.Tags = []string{"untagged"}
+				}
+			}
+
 			err = mainTpl.Execute(w, prog)
 			if err != nil {
 				_, wErr := fmt.Fprintf(w, "could not execute template: %v", err)


### PR DESCRIPTION
The template expects a tag to be there for grouping, this groups them as
untagged in the HTML response.