### PR TITLE
RFC: Syntax changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ type errorResponse struct {
 //
 // A more detailed multi-line description.
 //
-// Request body: $ref: bikeRequest
-// Response 200: $ref: bikeResponse
-// Response 400: $ref: errorResonse
+// Request body: bikeRequest
+// Response 200: bikeResponse
+// Response 400: errorResonse
 ```
 
 Configuration

--- a/config.example
+++ b/config.example
@@ -39,11 +39,11 @@ version 1.0
 # Set the default Content-Type for requests and responses; this means that
 # writing:
 #
-#   Request (application/json): $ref foo
+#   Request (application/json): foo
 #
 # can be shortened to:
 #
-#   Request: $ref foo
+#   Request: foo
 default-request-ct  application/json
 default-response-ct application/json
 
@@ -55,11 +55,11 @@ default-response-ct application/json
 # Instead of referring to the full types every time.
 #
 # The syntax is the same as regular Response lines, minus the Response keyword:
-#   [HTTP code] [(optional Content-Type)]: $ref: [type]
+#   [HTTP code] [(optional Content-Type)]: [type]
 #
 # Examples:
-#default-response 400: $ref: github.com/teamwork/validate.Validator
-#default-response 404 (application/json): $ref: github.com/teamwork/apiutil/errorhandler.Error
+#default-response 400: github.com/teamwork/validate.Validator
+#default-response 404 (application/json): github.com/teamwork/apiutil/errorhandler.Error
 
 # Prefix all paths with this before adding to the output.
 #prefix
@@ -81,7 +81,7 @@ default-response-ct application/json
 # be exposed in the user-facing documentation.
 #
 # The map target must be a Go built-in type (string, int64, etc.)
-map-types              
+map-types
 	# Standard library
 	sql.NullBool    bool
 	sql.NullFloat64 float64

--- a/doc/syntax.markdown
+++ b/doc/syntax.markdown
@@ -52,9 +52,9 @@ The general structure looks like:
     //
     // A more detailed multi-line description.
     //
-    // Request body: $ref: bikeRequest
-    // Response 200: $ref: bikeResponse
-    // Response 400: $ref: errorResonse
+    // Request body: bikeRequest
+    // Response 200: bikeResponse
+    // Response 400: errorResonse
 
 This describes the endpoint `POST /bike/{id}`, which will be grouped under
 `bikes`. It describes the JSON request body in the `bikeRequest` struct and the
@@ -116,7 +116,7 @@ Reference directives
 
 The general structure for referencing types is:
 
-    <keyword>: $ref: <ref>
+    <keyword>: <ref>
 
 The various values for `<keyword>` are described below.
 
@@ -155,7 +155,7 @@ A `Path` reference can be used to document path parameters; for example:
 
     // GET /bike/{id}
     //
-    // Path: $ref: pathParams
+    // Path: pathParams
 
 Attempting to document path parameters that don't exist as `{..}` placeholders
 in the path is an error.
@@ -171,65 +171,65 @@ or `multipart/form-data`).
 
 The `Form` and `Query` parameters follow the same format:
 
-    Form: $ref: formParams
-    Query: $ref: queryParams
+    Form: formParams
+    Query: queryParams
 
 Referencing Form, Path, or Query parameters will always use the `form`, `path`,
 and `query` struct tags. A value of `-` means it will be ignored; no struct tag
 means it will add the field name as-is.
 
-    param-ref      = ( "Form" / "Path" / "Query" ) ": $ref: " ref LF
+    param-ref      = ( "Form" / "Path" / "Query" ) ": " ref LF
 
 ### Request body
 
 The request body is any request body that is not a form; for example JSON, XML,
 YAML, or something else.
 
-    Request body: $ref: createRequest
-    Request body (application/xml): $ref: createRequest
+    Request body: createRequest
+    Request body (application/xml): createRequest
 
 The first form will use the configured default Content-Type; the second form
 explicitly defines it for this request body.
 
     content-type   = type-name "/" subtype-name  ; https://tools.ietf.org/html/rfc6838#section-4.2
-    request-ref    = "Request body" [ "(" content-type ")" ] ": $ref:" ref LF
+    request-ref    = "Request body" [ "(" content-type ")" ] ": " ref LF
 
 ### Responses
 
 Response bodies are mapped to a HTTP status code:
 
-    Response 200: $ref: createResponse
+    Response 200: createResponse
 
 Every endpoint must have at least one defined response.
 
 The response code `200` will be used it it's omitted:
 
-    Response: $ref: createResponse
+    Response: createResponse
 
 You can define a Content-Type like with Request bodies; it will use the
 configured default Content-Type if omitted:
 
-    Response 404 (application/json): $ref: createResponse
+    Response 404 (application/json): createResponse
 
-The `$empty` keyword indicates that this response code may be returned, but
+The `{empty}` keyword indicates that this response code may be returned, but
 without any code. In general this should only be used for `204 No Content`:
 
-    Response 204: $empty
+    Response 204: {empty}
 
-The `$data` keyword indicates that this response returns unstructured data, such
-as text, HTML, an image, spreadsheet document, etc. An explicit Content-Type is
-required when using `$data`.
+The `{data}` keyword indicates that this response returns unstructured data,
+such as text, HTML, an image, spreadsheet document, etc. An explicit
+Content-Type is required when using `{data}`.
 
-    Response 200 (text/plain): $data
+    Response 200 (text/plain): {data}
 
-The `$default` keyword indicates it should use the default reference for this
+The `{default}` keyword indicates it should use the default reference for this
 response code:
 
-    Response 400: $default
+    Response 400: {default}
 
 It is an error if no default reference is configured for this response code.
 
-    response-ref   = "Response" [ 3DIGIT ] ":" [ "(" content-type ")" ] ( "$empty" / "$default" / ": $ref:" ref ) LF
+    response-ref   = "Response" [ 3DIGIT ] ":" [ "(" content-type ")" ] ( "{empty}" / "{default}" / ": " ref ) LF
 
 References
 ----------

--- a/docparse/docparse_test.go
+++ b/docparse/docparse_test.go
@@ -24,8 +24,8 @@ func TestParseComments(t *testing.T) {
 POST /path
 The tagline!
 
-Request body (foo): $ref: net/mail.Address
-Response 200: $empty
+Request body (foo): net/mail.Address
+Response 200: {empty}
 			`,
 			"",
 			[]*Endpoint{{
@@ -43,8 +43,8 @@ Response 200: $empty
 POST /path
 GET /foo
 
-Request body (foo): $ref: net/mail.Address
-Response 200: $empty
+Request body (foo): net/mail.Address
+Response 200: {empty}
 			`,
 			"",
 			[]*Endpoint{{
@@ -65,8 +65,8 @@ POST /path
 GET /foo
 The tagline!
 
-Request body (foo): $ref: net/mail.Address
-Response 200: $empty
+Request body (foo): net/mail.Address
+Response 200: {empty}
 			`,
 			"",
 			[]*Endpoint{{
@@ -90,8 +90,8 @@ The tagline!
 
 Some desc!
 
-Request body (foo): $ref: net/mail.Address
-Response 200: $empty
+Request body (foo): net/mail.Address
+Response 200: {empty}
 			`,
 			"",
 			[]*Endpoint{{
@@ -114,8 +114,8 @@ POST /path
 
 A description.
 
-Request body (foo): $ref: net/mail.Address
-Response 200: $empty
+Request body (foo): net/mail.Address
+Response 200: {empty}
 			`,
 			"",
 			[]*Endpoint{{
@@ -135,8 +135,8 @@ POST /path
 A description.
 Of multiple lines.
 
-Request body (foo): $ref: net/mail.Address
-Response 200: $empty
+Request body (foo): net/mail.Address
+Response 200: {empty}
 			`,
 			"",
 			[]*Endpoint{{
@@ -160,8 +160,8 @@ With some more.
 
 And some more.
 
-Request body (foo): $ref: net/mail.Address
-Response 200: $empty
+Request body (foo): net/mail.Address
+Response 200: {empty}
 			`,
 			"",
 			[]*Endpoint{{
@@ -181,8 +181,8 @@ The tagline!
 
 A description.
 
-Request body (foo): $ref: net/mail.Address
-Response 200: $empty
+Request body (foo): net/mail.Address
+Response 200: {empty}
 			`,
 			"",
 			[]*Endpoint{{
@@ -204,8 +204,8 @@ The tagline!
 A description.
 Of multiple lines.
 
-Request body (foo): $ref: net/mail.Address
-Response 200: $empty
+Request body (foo): net/mail.Address
+Response 200: {empty}
 			`,
 			"",
 			[]*Endpoint{{
@@ -223,8 +223,8 @@ Response 200: $empty
 		{"req-ref", `
 POST /path
 
-Request body: $ref: net/mail.Address
-Response 200: $empty
+Request body: net/mail.Address
+Response 200: {empty}
 		`,
 			"",
 			[]*Endpoint{{
@@ -239,8 +239,8 @@ Response 200: $empty
 		{"path-ref", `
 POST /path/{Name}/{Address}
 
-Path: $ref: net/mail.Address
-Response 200: $empty
+Path: net/mail.Address
+Response 200: {empty}
 		`,
 			"",
 			[]*Endpoint{{
@@ -254,8 +254,8 @@ Response 200: $empty
 		{"req-content-type", `
 POST /path
 
-Request body (foo): $ref: net/mail.Address
-Response 200: $empty
+Request body (foo): net/mail.Address
+Response 200: {empty}
 			`,
 			"",
 			[]*Endpoint{{
@@ -271,8 +271,8 @@ Response 200: $empty
 		{"response-ref", `
 POST /path
 
-Response: $empty
-Response 400 (w00t): $empty
+Response: {empty}
+Response 400 (w00t): {empty}
 			`,
 			"",
 			[]*Endpoint{{
@@ -294,8 +294,8 @@ Response 400 (w00t): $empty
 		//{"err-double-code", `
 		//		POST /path
 
-		//		Response 200: $empty
-		//		Response 200: $empty
+		//		Response 200: {empty}
+		//		Response 200: {empty}
 		//	`, "response", nil},
 	}
 
@@ -390,7 +390,6 @@ func TestParseParams(t *testing.T) {
 		{"Hello {enum: one two three}", Param{Name: "Hello", Kind: "enum", KindEnum: []string{"one", "two", "three"}}, ""},
 
 		{"subject: The subject {required, pattern: [a-z]}", Param{}, "unknown parameter property"},
-		{"subject: foo\n$ref: testObject", Param{}, "both a reference and parameters are given"},
 	}
 
 	for i, tt := range tests {
@@ -558,7 +557,7 @@ func TestParseResponse(t *testing.T) {
 		wantErr  string
 	}{
 		{
-			"Response 400: $ref: net/mail.Address",
+			"Response 400: net/mail.Address",
 			400,
 			&Response{
 				ContentType: "application/json",
@@ -567,7 +566,7 @@ func TestParseResponse(t *testing.T) {
 			"",
 		},
 		{
-			"Response 400 $ref: net/mail.Address",
+			"Response 400 net/mail.Address",
 			0,
 			nil,
 			"",

--- a/docparse/find.go
+++ b/docparse/find.go
@@ -49,12 +49,6 @@ func FindComments(w io.Writer, prog *Program) error {
 					}
 				}
 
-				// For debugging one file.
-				// TODO: Should make "kommentaar ./api/v2/users.go" work.
-				//if relPath != "github.com/teamwork/desk/api/v2/users.go" {
-				//	continue
-				//}
-
 				for _, c := range f.Comments {
 					e, relLine, err := parseComment(prog, c.Text(), p.ImportPath, fullPath)
 					if err != nil {

--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -121,7 +121,6 @@ func setTags(name, fName string, p *Schema, tags []string) error {
 			// TODO: implement this (also load from struct tag?), but I don't
 			// see any way to do that in the OpenAPI spec?
 			return fmt.Errorf("omitempty not implemented yet")
-		// TODO
 		case paramReadOnly:
 			t := true
 			p.Readonly = &t

--- a/docparse/testdata/src/a/a.go
+++ b/docparse/testdata/src/a/a.go
@@ -5,7 +5,7 @@ import "net/mail"
 
 // GET /
 //
-// Response: $ref: foo
+// Response: foo
 
 // doc
 type foo struct {

--- a/example/example.go
+++ b/example/example.go
@@ -13,10 +13,10 @@ import (
 // This will create a new foo object for a customer. It's important to remember
 // that only Pro customers have access to foos.
 //
-// Request body (application/json): $ref: RequestObj
-// Response 200 (application/json): $ref: AnObject
-// Response 400 (application/json): $ref: ErrorObject
-// Response 401 (application/json): $ref: exampleimport.Foo
+// Request body (application/json): RequestObj
+// Response 200 (application/json): AnObject
+// Response 400 (application/json): ErrorObject
+// Response 401 (application/json): exampleimport.Foo
 
 // These docs are general Go docs, and not parsed (note the blank line).
 // Actually, the above OpenAPI block could be anywhere in the code; and doesn't
@@ -36,7 +36,7 @@ type formParams struct {
 //
 // Just to see if that works correct.
 //
-// Response 200: $empty
+// Response 200: {empty}
 
 // Other others a lot!
 func Other() {

--- a/example/second.go
+++ b/example/second.go
@@ -4,8 +4,8 @@ package example
 //
 // ANOTHER FILE!
 //
-// Request body: $ref: net/mail.Address
-// Response 200: $ref: AnObject
-// Response 400: $ref: ErrorObject
+// Request body: net/mail.Address
+// Response 200: AnObject
+// Response 400: ErrorObject
 
 // Response 401: $object: exampleimport.Foo

--- a/example/unified.go
+++ b/example/unified.go
@@ -36,32 +36,32 @@ type QueryParams struct {
 // GET /entities.json
 // List of entities paginated.
 //
-// Query: $ref: QueryParams
-// Response 400: $empty
+// Query: QueryParams
+// Response 400: {empty}
 func ListEntities() {}
 
 // GET /entities/{id}.json
 // Get entity by id
 //
-// Query: $ref: QueryParams
-// Response 200: $ref: entityResponse
-// Response 400: $empty
+// Query: QueryParams
+// Response 200: entityResponse
+// Response 400: {empty}
 func GetEntity() {}
 
 // POST /entities.json
 // Create an entity
 //
-// Request body: $ref: entity
-// Response 200: $ref: entityResponse
-// Response 400: $empty
+// Request body: entity
+// Response 200: entityResponse
+// Response 400: {empty}
 func PostEntity() {}
 
 // PATCH /entities/{id}.json
 // Update an entity
 //
-// Request body: $ref: entity
-// Response 200: $ref: entityResponse
-// Response 400: $empty
+// Request body: entity
+// Response 200: entityResponse
+// Response 400: {empty}
 func PatchEntity() {}
 
 // overriding the docs for id
@@ -72,7 +72,7 @@ type deletePathParams struct {
 // DELETE /entities/{id}.json
 // Delete an entity
 //
-// Path: $ref: deletePathParams
-// Response 204: $empty
-// Response 400: $empty
+// Path: deletePathParams
+// Response 204: {empty}
+// Response 400: {empty}
 func DeleteEntity() {}

--- a/kconfig/kconfig_test.go
+++ b/kconfig/kconfig_test.go
@@ -14,8 +14,8 @@ func TestLoad(t *testing.T) {
 	}{
 		{"example", test.Read(t, "../config.example")},
 		{"default-response", []byte(test.NormalizeIndent(`
-			default-response 400: $ref: github.com/teamwork/kommentaar/docparse.Param
-			default-response 404 (application/json): $ref: net/mail.Address
+			default-response 400: github.com/teamwork/kommentaar/docparse.Param
+			default-response 404 (application/json): net/mail.Address
 		`))},
 	}
 

--- a/testdata/openapi2/src/blank-line/in.go
+++ b/testdata/openapi2/src/blank-line/in.go
@@ -9,11 +9,11 @@ type formRef struct{}
 // POST /path tag
 //
 //
-// Path: $ref: pathRef
+// Path: pathRef
 //
 //
-// Query: $ref: queryRef
+// Query: queryRef
 //
-// Form: $ref: formRef
-// Response 200: $empty
+// Form: formRef
+// Response 200: {empty}
 //

--- a/testdata/openapi2/src/export/in.go
+++ b/testdata/openapi2/src/export/in.go
@@ -12,6 +12,6 @@ type ref2 struct {
 
 // POST /path
 //
-// Query: $ref: ref
-// Request body: $ref: ref2
-// Response 200: $empty
+// Query: ref
+// Request body: ref2
+// Response 200: {empty}

--- a/testdata/openapi2/src/interface/in.go
+++ b/testdata/openapi2/src/interface/in.go
@@ -19,4 +19,4 @@ type fooer interface{}
 
 // GET /path
 //
-// Response 200: $ref: resp
+// Response 200: resp

--- a/testdata/openapi2/src/invalid-default/in.go
+++ b/testdata/openapi2/src/invalid-default/in.go
@@ -4,4 +4,4 @@ type respRef struct{}
 
 // POST /path
 //
-// Response 419: $default
+// Response 419: {default}

--- a/testdata/openapi2/src/invalid-directive/in.go
+++ b/testdata/openapi2/src/invalid-directive/in.go
@@ -4,6 +4,6 @@ type reqRef struct{}
 
 // POST /path
 //
-// Request body: $ref: reqRef
-// Response 200: $empty
+// Request body: reqRef
+// Response 200: {empty}
 // Invalid header

--- a/testdata/openapi2/src/invalid-param-prop/in.go
+++ b/testdata/openapi2/src/invalid-param-prop/in.go
@@ -6,5 +6,5 @@ type queryRef struct {
 
 // POST /path
 //
-// Query: $ref: queryRef
-// Response 200: $empty
+// Query: queryRef
+// Response 200: {empty}

--- a/testdata/openapi2/src/invalid-path-param/in.go
+++ b/testdata/openapi2/src/invalid-path-param/in.go
@@ -8,5 +8,5 @@ type pathRef struct {
 
 // POST /path/{companyID}/{id} tag
 //
-// Path: $ref: pathRef
-// Response 200: $empty
+// Path: pathRef
+// Response 200: {empty}

--- a/testdata/openapi2/src/invalid-ref/in.go
+++ b/testdata/openapi2/src/invalid-ref/in.go
@@ -2,5 +2,5 @@ package path
 
 // POST /path/{id} tag
 //
-// Path: $ref: doesntExist
-// Response 200: $empty
+// Path: doesntExist
+// Response 200: {empty}

--- a/testdata/openapi2/src/invalid-resp-data-no-ct/in.go
+++ b/testdata/openapi2/src/invalid-resp-data-no-ct/in.go
@@ -2,5 +2,5 @@ package req
 
 // POST /path
 //
-// Response 200: $data
-// Response 400: $empty
+// Response 200: {data}
+// Response 400: {empty}

--- a/testdata/openapi2/src/invalid-resp-data-no-ct/wantErr
+++ b/testdata/openapi2/src/invalid-resp-data-no-ct/wantErr
@@ -1,1 +1,1 @@
-explicit Content-Type required for $data
+explicit Content-Type required for {data}

--- a/testdata/openapi2/src/invalid-unexported/in.go
+++ b/testdata/openapi2/src/invalid-unexported/in.go
@@ -7,5 +7,5 @@ type ref struct {
 
 // POST /path
 //
-// Query: $ref: ref
-// Response 200: $empty
+// Query: ref
+// Response 200: {empty}

--- a/testdata/openapi2/src/multiple-routes/in.go
+++ b/testdata/openapi2/src/multiple-routes/in.go
@@ -17,7 +17,7 @@ type formRef struct {
 //
 // Desc
 //
-// Path: $ref: pathRef
-// Query: $ref: queryRef
-// Form: $ref: formRef
-// Response 200: $empty
+// Path: pathRef
+// Query: queryRef
+// Form: formRef
+// Response 200: {empty}

--- a/testdata/openapi2/src/no-resp/in.go
+++ b/testdata/openapi2/src/no-resp/in.go
@@ -4,4 +4,4 @@ type reqRef struct{}
 
 // POST /path
 //
-// Request body: $ref: reqRef
+// Request body: reqRef

--- a/testdata/openapi2/src/param-schema/in.go
+++ b/testdata/openapi2/src/param-schema/in.go
@@ -20,5 +20,5 @@ type a struct {
 
 // POST /path
 //
-// Request body: $ref: a
-// Response 200: $ref: a
+// Request body: a
+// Response 200: a

--- a/testdata/openapi2/src/params-embed/in.go
+++ b/testdata/openapi2/src/params-embed/in.go
@@ -16,5 +16,5 @@ type queryRef struct {
 
 // GET /path
 //
-// Query: $ref: queryRef
-// Response 200: $empty
+// Query: queryRef
+// Response 200: {empty}

--- a/testdata/openapi2/src/params/in.go
+++ b/testdata/openapi2/src/params/in.go
@@ -13,7 +13,7 @@ type formRef struct {
 
 // POST /path/{id} tag
 //
-// Path: $ref: pathRef
-// Query: $ref: queryRef
-// Form: $ref: formRef
-// Response 200: $empty
+// Path: pathRef
+// Query: queryRef
+// Form: formRef
+// Response 200: {empty}

--- a/testdata/openapi2/src/path-duplicate/in.go
+++ b/testdata/openapi2/src/path-duplicate/in.go
@@ -4,6 +4,6 @@ type pathRef struct{}
 
 // POST /path/{id} tag
 //
-// Path: $ref: pathRef
-// Path: $ref: pathRef
-// Response 200: $empty
+// Path: pathRef
+// Path: pathRef
+// Response 200: {empty}

--- a/testdata/openapi2/src/path-fields/in.go
+++ b/testdata/openapi2/src/path-fields/in.go
@@ -8,5 +8,5 @@ type pathRef struct {
 
 // POST /path/{companyID}/{id} tag
 //
-// Path: $ref: pathRef
-// Response 200: $empty
+// Path: pathRef
+// Response 200: {empty}

--- a/testdata/openapi2/src/path-generated/in.go
+++ b/testdata/openapi2/src/path-generated/in.go
@@ -2,4 +2,4 @@ package path
 
 // POST /path/{companyID}/{id} tag
 //
-// Response 200: $empty
+// Response 200: {empty}

--- a/testdata/openapi2/src/path-invalid-tagline/in.go
+++ b/testdata/openapi2/src/path-invalid-tagline/in.go
@@ -11,5 +11,5 @@ type pathRef struct{}
 //
 // Description.
 //
-// Path: $re: pathRef
-// Response 200: $empty
+// Path: {invalid}
+// Response 200: {empty}

--- a/testdata/openapi2/src/path-invalid-tagline/wantErr
+++ b/testdata/openapi2/src/path-invalid-tagline/wantErr
@@ -1,1 +1,1 @@
-path-invalid-tagline/in.go:14 could not parse Path params: invalid keyword: "$re"
+path-invalid-tagline/in.go:14 could not parse Path params: invalid keyword: "{invalid}"

--- a/testdata/openapi2/src/path-invalid/in.go
+++ b/testdata/openapi2/src/path-invalid/in.go
@@ -4,5 +4,5 @@ type pathRef struct{}
 
 // POST /path/{id} tag
 //
-// Path: $re: pathRef
-// Response 200: $empty
+// Path: {invalid}
+// Response 200: {empty}

--- a/testdata/openapi2/src/path-invalid/wantErr
+++ b/testdata/openapi2/src/path-invalid/wantErr
@@ -1,1 +1,1 @@
-path-invalid/in.go:7 could not parse Path params: invalid keyword: "$re"
+path-invalid/in.go:7 could not parse Path params: invalid keyword: "{invalid}"

--- a/testdata/openapi2/src/req-ct/in.go
+++ b/testdata/openapi2/src/req-ct/in.go
@@ -4,5 +4,5 @@ type reqRef struct{}
 
 // POST /path
 //
-// Request body (text/plain): $ref: reqRef
-// Response 200: $empty
+// Request body (text/plain): reqRef
+// Response 200: {empty}

--- a/testdata/openapi2/src/req-duplicate/in.go
+++ b/testdata/openapi2/src/req-duplicate/in.go
@@ -4,6 +4,6 @@ type reqRef struct{}
 
 // POST /path
 //
-// Request body: $ref: reqRef
-// Request body: $ref: reqRef
-// Response 200: $empty
+// Request body: reqRef
+// Request body: reqRef
+// Response 200: {empty}

--- a/testdata/openapi2/src/req/in.go
+++ b/testdata/openapi2/src/req/in.go
@@ -4,5 +4,5 @@ type reqRef struct{}
 
 // POST /path
 //
-// Request body: $ref: reqRef
-// Response 200: $empty
+// Request body: reqRef
+// Response 200: {empty}

--- a/testdata/openapi2/src/resp-ct/in.go
+++ b/testdata/openapi2/src/resp-ct/in.go
@@ -4,4 +4,4 @@ type respRef struct{}
 
 // POST /path
 //
-// Response 200 (text/plain): $ref: respRef
+// Response 200 (text/plain): respRef

--- a/testdata/openapi2/src/resp-data/in.go
+++ b/testdata/openapi2/src/resp-data/in.go
@@ -2,5 +2,5 @@ package req
 
 // POST /path
 //
-// Response 200 (text/plain): $data
-// Response 400: $empty
+// Response 200 (text/plain): {data}
+// Response 400: {empty}

--- a/testdata/openapi2/src/resp-default/in.go
+++ b/testdata/openapi2/src/resp-default/in.go
@@ -4,4 +4,4 @@ type respRef struct{}
 
 // POST /path
 //
-// Response 418: $default
+// Response 418: {default}

--- a/testdata/openapi2/src/resp-default/test.conf
+++ b/testdata/openapi2/src/resp-default/test.conf
@@ -6,9 +6,9 @@
 # Instead of referring to the full types every time.
 #
 # The syntax is the same as regular Response lines, minus the Response keyword:
-#   [HTTP code] [(optional Content-Type)]: $ref: [type]
+#   [HTTP code] [(optional Content-Type)]: [type]
 #
 # Examples:
-#default-response 400: $ref: github.com/teamwork/validate.Validator
-#default-response 404 (application/json): $ref: github.com/teamwork/apiutil/errorhandler.Error
-default-response 418 (application/teapot): $ref: net/mail.Address
+#default-response 400: github.com/teamwork/validate.Validator
+#default-response 404 (application/json): github.com/teamwork/apiutil/errorhandler.Error
+default-response 418 (application/teapot): net/mail.Address

--- a/testdata/openapi2/src/resp-duplicate/in.go
+++ b/testdata/openapi2/src/resp-duplicate/in.go
@@ -2,5 +2,5 @@ package req
 
 // POST /path
 //
-// Response 200: $empty
-// Response 200: $empty
+// Response 200: {empty}
+// Response 200: {empty}

--- a/testdata/openapi2/src/struct-anon/in.go
+++ b/testdata/openapi2/src/struct-anon/in.go
@@ -12,4 +12,4 @@ type resp struct {
 
 // POST /path
 //
-// Response 200: $ref: resp
+// Response 200: resp

--- a/testdata/openapi2/src/struct-embed/in.go
+++ b/testdata/openapi2/src/struct-embed/in.go
@@ -20,4 +20,4 @@ type Tagged struct {
 
 // POST /path
 //
-// Response 200: $ref: resp
+// Response 200: resp

--- a/testdata/openapi2/src/struct-map/in.go
+++ b/testdata/openapi2/src/struct-map/in.go
@@ -19,4 +19,4 @@ type aStruct struct {
 
 // POST /path
 //
-// Response 200: $ref: resp
+// Response 200: resp

--- a/testdata/openapi2/src/struct-mapping/in.go
+++ b/testdata/openapi2/src/struct-mapping/in.go
@@ -18,5 +18,5 @@ type NullableString struct {
 
 // POST /path
 //
-// Request body: $ref: a
-// Response 200: $ref: a
+// Request body: a
+// Response 200: a

--- a/testdata/openapi2/src/struct-omitdoc/in.go
+++ b/testdata/openapi2/src/struct-omitdoc/in.go
@@ -26,8 +26,8 @@ type resp struct {
 
 // POST /path/{companyID}/{id}
 //
-// Path:         $ref: pathRef
-// Query:        $ref: queryRef
-// Form:         $ref: formRef
-// Request body: $ref: req
-// Response 200: $ref: resp
+// Path:         pathRef
+// Query:        queryRef
+// Form:         formRef
+// Request body: req
+// Response 200: resp

--- a/testdata/openapi2/src/struct-readonly/in.go
+++ b/testdata/openapi2/src/struct-readonly/in.go
@@ -10,6 +10,6 @@ type reqRef struct {
 
 // POST /path
 //
-// Query: $ref: queryRef
-// Request body: $ref: reqRef
-// Response 200: $empty
+// Query: queryRef
+// Request body: reqRef
+// Response 200: {empty}

--- a/testdata/openapi2/src/struct-required/in.go
+++ b/testdata/openapi2/src/struct-required/in.go
@@ -18,6 +18,6 @@ type req struct {
 
 // POST /path
 //
-// Query: $ref: queryRef
-// Request body: $ref: req
-// Response 200: $empty
+// Query: queryRef
+// Request body: req
+// Response 200: {empty}

--- a/testdata/openapi2/src/struct-slice/in.go
+++ b/testdata/openapi2/src/struct-slice/in.go
@@ -26,4 +26,4 @@ type deal struct {
 
 // POST /path
 //
-// Response 200: $ref: resp
+// Response 200: resp

--- a/testdata/openapi2/src/struct-tag/in.go
+++ b/testdata/openapi2/src/struct-tag/in.go
@@ -6,5 +6,5 @@ type reqRef struct {
 
 // POST /path
 //
-// Request body: $ref: reqRef
-// Response 200: $empty
+// Request body: reqRef
+// Response 200: {empty}

--- a/testdata/openapi2/src/type-block/in.go
+++ b/testdata/openapi2/src/type-block/in.go
@@ -7,5 +7,5 @@ type (
 
 // POST /path
 //
-// Request body: $ref: reqRef
-// Response 200: $empty
+// Request body: reqRef
+// Response 200: {empty}


### PR DESCRIPTION
This is just a proposal, no functional changes yet:

1) Drop `$ref`; you can now use this:

    Path: createRequest

The reason `$ref` was used in the first place was because originally you
could describe parameters inline:

    Path:
        id (int): The foo ID.

So a special "keyword" was needed to distinguish between inline
parameters and references to types.

But suppor for this has long been removed, so it's no longer needed.
It's just overly verbose.

2) Use `{keyword}` instead of `$keyword` for reference directives.

This is more consistent with how keywords are formatted in parameters
(e.g. `{required}`).

---

Both changes will make adding variables (#59) easier, so you can do:

    GET /foo

    Get the foo object. This endpoint is limited to $rateLimit requests
    per second.

    Response body: fooType

It's also simpler syntax, which should make it easier to use for people.

Should be easy to `sed` existing projects to the new syntax.