### PR TITLE
implement filters for list endpoints

### DIFF
--- a/docparse/docparse.go
+++ b/docparse/docparse.go
@@ -306,7 +306,8 @@ func parseComment(prog *Program, comment, pkgPath, filePath string) ([]*Endpoint
 
 			split := strings.SplitN(filter[1], ".", 2)
 			if len(split) < 2 {
-				return nil, i, fmt.Errorf("could not parse filter type: %v", filter[1])
+				// look for it in same package
+				split = []string{".", split[0]}
 			}
 			pkg := split[0]
 			typ := split[1]

--- a/docparse/docparse_test.go
+++ b/docparse/docparse_test.go
@@ -3,6 +3,7 @@ package docparse
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/teamwork/test"
@@ -589,4 +590,43 @@ func TestParseResponse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseRequestFilter(t *testing.T) {
+	tests := []struct {
+		in          string
+		wantFields  string
+		wantFilters string
+		wantErr     bool
+	}{
+		{
+			`GET /test test
+test desc
+
+Request filter: testObject
+Response 200: {empty}
+`,
+			`Filters: a, c`,
+			`SortableFields: e, g`,
+			false,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			prog := NewProgram(false)
+			out, _, err := parseComment(prog, tt.in, ".", "test.go")
+			if err != nil {
+				t.Fatal(err)
+			}
+			info := out[0].Info
+			if !strings.Contains(string(info), tt.wantFields) {
+				t.Errorf("%v missing", tt.wantFields)
+			}
+			if !strings.Contains(string(info), tt.wantFilters) {
+				t.Errorf("%v missing", tt.wantFilters)
+			}
+		})
+	}
+
 }

--- a/docparse/test.go
+++ b/docparse/test.go
@@ -15,3 +15,16 @@ type testObject struct {
 
 	Bar []string
 }
+
+func (t testObject) FilterFieldMap() map[string]string {
+	return map[string]string{
+		"a": "b",
+		"c": "d",
+	}
+}
+func (t testObject) SortFieldMap() map[string]string {
+	return map[string]string{
+		"e": "f",
+		"g": "h",
+	}
+}

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -157,7 +157,7 @@ func write(outFormat string, w io.Writer, prog *docparse.Program) error {
 
 		op := Operation{
 			Summary:     e.Tagline,
-			Description: e.Info,
+			Description: string(e.Info),
 			OperationID: makeID(e),
 			Tags:        e.Tags,
 			Responses:   map[int]Response{},


### PR DESCRIPTION
This add support for listing filterable and sortable fields for Desk endpoints.

### Usage. 
Specify model that implements `FilterFieldMap` and `SortFieldMap`.
```
// Request filter: models.Customer
```

### Output
Filterable and Sortable fields show in openapi.

![Screenshot from 2019-07-30 21-09-37](https://user-images.githubusercontent.com/240448/62307511-a395ee80-b47b-11e9-9367-a657a36f8a41.png)



