### PR TITLE
Add tags property to output

### DIFF
--- a/testdata/openapi2/src/blank-line/want.json
+++ b/testdata/openapi2/src/blank-line/want.json
@@ -11,6 +11,11 @@
   "produces": [
     "application/json"
   ],
+  "tags": [
+    {
+      "name": "tag"
+    }
+  ],
   "paths": {
     "/path": {
       "post": {

--- a/testdata/openapi2/src/blank-line/want.yaml
+++ b/testdata/openapi2/src/blank-line/want.yaml
@@ -6,6 +6,8 @@ consumes:
 - application/json
 produces:
 - application/json
+tags:
+- name: tag
 paths:
   /path:
     post:

--- a/testdata/openapi2/src/multiple-routes/want.yaml
+++ b/testdata/openapi2/src/multiple-routes/want.yaml
@@ -6,6 +6,9 @@ consumes:
 - application/json
 produces:
 - application/json
+tags:
+- name: somethingelse
+- name: tag
 paths:
   /bar:
     put:

--- a/testdata/openapi2/src/params/want.yaml
+++ b/testdata/openapi2/src/params/want.yaml
@@ -6,6 +6,8 @@ consumes:
 - application/json
 produces:
 - application/json
+tags:
+- name: tag
 paths:
   /path/{id}:
     post:

--- a/testdata/openapi2/src/path-fields/want.yaml
+++ b/testdata/openapi2/src/path-fields/want.yaml
@@ -6,6 +6,8 @@ consumes:
 - application/json
 produces:
 - application/json
+tags:
+- name: tag
 paths:
   /path/{companyID}/{id}:
     post:

--- a/testdata/openapi2/src/path-generated/want.yaml
+++ b/testdata/openapi2/src/path-generated/want.yaml
@@ -6,6 +6,8 @@ consumes:
 - application/json
 produces:
 - application/json
+tags:
+- name: tag
 paths:
   /path/{companyID}/{id}:
     post:


### PR DESCRIPTION
Adds the tags property to the OpenAPI root object with all the tags that
occurred in the output sorted. We currently output the tags to the endpoint but
some tools use the top level tags array for the ordering of them.

This supports extra properties where you can add a description so this could be
configuration based at some point, but will take this simple approach unless
somebody else requires it.

See: https://swagger.io/specification/