### PR TITLE
Skip omitted fields in GetReference

### DIFF
--- a/docparse/docparse.go
+++ b/docparse/docparse.go
@@ -505,6 +505,10 @@ func parseRefValue(prog *Program, context, value, filePath string) (*Ref, error)
 	return params, nil
 }
 
+func hasTag(s, tag string) bool {
+	return strings.Contains(s, fmt.Sprintf("{%s}", tag))
+}
+
 // parseTags get tags from {..} blocks.
 func parseTags(line string) (string, []string) {
 	var alltags []string

--- a/docparse/docparse.go
+++ b/docparse/docparse.go
@@ -157,6 +157,12 @@ type Reference struct {
 }
 
 const (
+	ctxForm  = "form"
+	ctxPath  = "path"
+	ctxQuery = "query"
+	ctxReq   = "req"
+	ctxResp  = "resp"
+
 	refDefault = "{default}"
 	refEmpty   = "{empty}"
 	refData    = "{data}"

--- a/docparse/find.go
+++ b/docparse/find.go
@@ -363,9 +363,9 @@ func GetReference(prog *Program, context string, isEmbed bool, lookup, filePath 
 
 	var tagName string
 	switch ref.Context {
-	case "path", "query", "form":
+	case ctxPath, ctxQuery, ctxForm:
 		tagName = ref.Context
-	case "req", "resp":
+	case ctxReq, ctxResp:
 		tagName = prog.Config.StructTag
 	default:
 		return nil, fmt.Errorf("invalid context: %q", context)
@@ -375,7 +375,7 @@ func GetReference(prog *Program, context string, isEmbed bool, lookup, filePath 
 	// TODO(param): only reason we do this is to make things a bit easier during
 	// refactor. We should pass st to structToSchema() or something.
 	for _, f := range st.Fields.List {
-		if f.Comment != nil && ref.Context != "path" {
+		if f.Comment != nil && ref.Context != ctxPath {
 			if hasTag(f.Comment.Text(), paramOmitDoc) {
 				continue
 			}
@@ -432,7 +432,7 @@ func GetReference(prog *Program, context string, isEmbed bool, lookup, filePath 
 	// Scan all fields of f if it refers to a struct. Do this after storing the
 	// reference in prog.References to prevent cyclic lookup issues.
 	for _, f := range st.Fields.List {
-		if f.Comment != nil && ref.Context != "path" {
+		if f.Comment != nil && ref.Context != ctxPath {
 			if hasTag(f.Comment.Text(), paramOmitDoc) {
 				continue
 			}

--- a/docparse/find.go
+++ b/docparse/find.go
@@ -375,6 +375,11 @@ func GetReference(prog *Program, context string, isEmbed bool, lookup, filePath 
 	// TODO(param): only reason we do this is to make things a bit easier during
 	// refactor. We should pass st to structToSchema() or something.
 	for _, f := range st.Fields.List {
+		if f.Comment != nil {
+			if hasTag(f.Comment.Text(), paramOmitDoc) {
+				continue
+			}
+		}
 
 		if len(f.Names) == 0 {
 			// Skip embedded structs without tags; we merge them later.
@@ -427,6 +432,12 @@ func GetReference(prog *Program, context string, isEmbed bool, lookup, filePath 
 	// Scan all fields of f if it refers to a struct. Do this after storing the
 	// reference in prog.References to prevent cyclic lookup issues.
 	for _, f := range st.Fields.List {
+		if f.Comment != nil {
+			if hasTag(f.Comment.Text(), paramOmitDoc) {
+				continue
+			}
+		}
+
 		var isEmbed bool
 		if len(f.Names) == 0 {
 			isEmbed = true

--- a/docparse/find.go
+++ b/docparse/find.go
@@ -375,7 +375,7 @@ func GetReference(prog *Program, context string, isEmbed bool, lookup, filePath 
 	// TODO(param): only reason we do this is to make things a bit easier during
 	// refactor. We should pass st to structToSchema() or something.
 	for _, f := range st.Fields.List {
-		if f.Comment != nil {
+		if f.Comment != nil && ref.Context != "path" {
 			if hasTag(f.Comment.Text(), paramOmitDoc) {
 				continue
 			}
@@ -432,7 +432,7 @@ func GetReference(prog *Program, context string, isEmbed bool, lookup, filePath 
 	// Scan all fields of f if it refers to a struct. Do this after storing the
 	// reference in prog.References to prevent cyclic lookup issues.
 	for _, f := range st.Fields.List {
-		if f.Comment != nil {
+		if f.Comment != nil && ref.Context != "path" {
 			if hasTag(f.Comment.Text(), paramOmitDoc) {
 				continue
 			}


### PR DESCRIPTION
Saves doing some unneeded work, but the real reason for this change is so I can
safely ignore some module enabled dep which kommentaar currently doesn't support.