### PR TITLE
Add support for mapping ids to entities in responses

### DIFF
--- a/docparse/find.go
+++ b/docparse/find.go
@@ -297,6 +297,7 @@ func (err ErrNotStruct) Error() string {
 func GetReference(prog *Program, context string, isEmbed bool, lookup, filePath string) (*Reference, error) {
 	wrapper := ""
 	isSlice := false
+	isMap := false
 	if strings.HasPrefix(lookup, "[") && strings.HasSuffix(lookup, "]") && strings.Contains(lookup, ":") {
 		wrapper = strings.TrimPrefix(strings.Split(lookup, ":")[0], "[")
 		lookup = strings.TrimSuffix(strings.Split(lookup, ":")[1], "]")
@@ -340,17 +341,6 @@ func GetReference(prog *Program, context string, isEmbed bool, lookup, filePath 
 			arLookup = fmt.Sprintf("[%v:%v]", wrapper, arLookup)
 		}
 		return GetReference(prog, context, isEmbed, arLookup, filePath)
-	case *ast.MapType:
-		// TODO, create the additional properties thing
-		var mp *ast.MapType = typ
-		ident, ok := mp.Value.(*ast.Ident)
-		if ok {
-			fmt.Printf("# ***** Is Ident %#v\n", ident)
-			panic("Is Ident")
-		} else {
-			fmt.Printf("# ***** Don't know what is this %#v", mp)
-			panic("Is not ident")
-		}
 	default:
 		return nil, ErrNotStruct{ts, fmt.Sprintf(
 			"%v is not a struct or interface but a %T", name, ts.Type)}

--- a/docparse/find.go
+++ b/docparse/find.go
@@ -297,7 +297,6 @@ func (err ErrNotStruct) Error() string {
 func GetReference(prog *Program, context string, isEmbed bool, lookup, filePath string) (*Reference, error) {
 	wrapper := ""
 	isSlice := false
-	isMap := false
 	if strings.HasPrefix(lookup, "[") && strings.HasSuffix(lookup, "]") && strings.Contains(lookup, ":") {
 		wrapper = strings.TrimPrefix(strings.Split(lookup, ":")[0], "[")
 		lookup = strings.TrimSuffix(strings.Split(lookup, ":")[1], "]")

--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -373,13 +373,14 @@ start:
 			return &p, nil
 		}
 
-		_, ref, err := lookupTypeAndRef(ref.File, vpkg, vtyp.Name)
+		_, lref, err := lookupTypeAndRef(ref.File, vpkg, vtyp.Name)
 		if err == nil {
 			// found additional properties
-			p.AdditionalProperties = &Schema{Reference: ref}
-			dbg("FOUND ADDITIONAL PROPERTIES: %s in %s", ref, pkg)
+			p.AdditionalProperties = &Schema{Reference: lref}
+			// Make sure the reference is added to `prog.References`:
+			GetReference(prog, ref.Context, false, lref, ref.File)
 		} else {
-			dbg("ERR FOUND ADDITIONAL PROPERTIES: %s", err.Error())
+			dbg("ERR, Could not find additionalProperties: %s", err.Error())
 		}
 		return &p, nil
 

--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -465,17 +465,6 @@ func lookupTypeAndRef(file, pkg, name string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	/*
-		ident, ok := ts.Name.(*ast.Ident)
-		if !ok {
-			// in getTypeInfo, there is a special case for anonymous stucts ?
-			// but I am not sure how can we be looking up for an anonymous struct
-			// O_o
-			return "", "", fmt.Errorf("could not find ident for file: %s, pkg: %s, name: %s",
-				file, pkg, name)
-		}
-		t := JSONSchemaType(ident.Name)
-	*/
 	t := JSONSchemaType(ts.Name.Name)
 
 	sRef := lookup

--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -461,15 +461,18 @@ func lookupTypeAndRef(file, pkg, name string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	ident, ok := ts.Type.(*ast.Ident)
-	if !ok {
-		// in getTypeInfo, there is a special case for anonymous stucts ?
-		// but I am not sure how can we be looking up for an anonymous struct
-		// O_o
-		return "", "", fmt.Errorf("could not find ident for file: %s, pkg: %s, name: %s",
-			file, pkg, name)
-	}
-	t := JSONSchemaType(ident.Name)
+	/*
+		ident, ok := ts.Name.(*ast.Ident)
+		if !ok {
+			// in getTypeInfo, there is a special case for anonymous stucts ?
+			// but I am not sure how can we be looking up for an anonymous struct
+			// O_o
+			return "", "", fmt.Errorf("could not find ident for file: %s, pkg: %s, name: %s",
+				file, pkg, name)
+		}
+		t := JSONSchemaType(ident.Name)
+	*/
+	t := JSONSchemaType(ts.Name.Name)
 
 	sRef := lookup
 	if i := strings.LastIndex(pkg, "/"); i > -1 {

--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -378,7 +378,10 @@ start:
 			// found additional properties
 			p.AdditionalProperties = &Schema{Reference: lref}
 			// Make sure the reference is added to `prog.References`:
-			GetReference(prog, ref.Context, false, lref, ref.File)
+			_, err := GetReference(prog, ref.Context, false, lref, ref.File)
+			if err != nil {
+				dbg("ERR, Could not find additionalProperties Reference: %s", err.Error())
+			}
 		} else {
 			dbg("ERR, Could not find additionalProperties: %s", err.Error())
 		}
@@ -428,7 +431,7 @@ start:
 
 func dropTypePointers(typ ast.Expr) ast.Expr {
 	var t *ast.StarExpr
-	ok := true
+	var ok bool
 	for t, ok = typ.(*ast.StarExpr); ok; t, ok = typ.(*ast.StarExpr) {
 		typ = t.X
 	}

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -478,6 +478,11 @@ func prefixPropertyReferences(properties map[string]*docparse.Schema) {
 				s.Items.Reference = "#/definitions/" + s.Items.Reference
 			}
 		}
+		if s.AdditionalProperties != nil && s.AdditionalProperties.Reference != "" {
+			if !strings.HasPrefix(s.AdditionalProperties.Reference, "#/definitions/") {
+				s.AdditionalProperties.Reference = "#/definitions/" + s.AdditionalProperties.Reference
+			}
+		}
 
 		if s.OmitDoc {
 			rm = append(rm, k)

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -278,11 +278,18 @@ func write(outFormat string, w io.Writer, prog *docparse.Program) error {
 					continue
 				}
 
+				queryType := schema.Type
+				if len(queryType) == 0 {
+					// if the parameter is a struct, and not mapped,
+					// we should fallback to a string to have a valid swagger file
+					// (we can not have a field without schema nor type )
+					queryType = "string"
+				}
 				op.Parameters = append(op.Parameters, Parameter{
 					Name:        f.Name,
 					In:          "query",
 					Description: schema.Description,
-					Type:        schema.Type,
+					Type:        queryType,
 					Items:       schema.Items,
 					Required:    len(schema.Required) > 0,
 					Readonly:    schema.Readonly,
@@ -317,11 +324,18 @@ func write(outFormat string, w io.Writer, prog *docparse.Program) error {
 					continue
 				}
 
+				formType := schema.Type
+				if len(formType) == 0 {
+					// if the parameter is a struct, and not mapped,
+					// we should fallback to a string to have a valid swagger file
+					// (we can not have a field without schema nor type )
+					formType = "string"
+				}
 				op.Parameters = append(op.Parameters, Parameter{
 					Name:        f.Name,
 					In:          "formData",
 					Description: schema.Description,
-					Type:        schema.Type,
+					Type:        formType,
 					Items:       schema.Items,
 					Required:    len(schema.Required) > 0,
 					Readonly:    schema.Readonly,

--- a/testdata/openapi2/src/struct-map/want.yaml
+++ b/testdata/openapi2/src/struct-map/want.yaml
@@ -46,5 +46,7 @@ definitions:
       custom:
         description: Custom comment.
         type: object
+        additionalProperties:
+          type: string
       otherStruct:
         $ref: '#/definitions/otherpkg.OtherStruct'


### PR DESCRIPTION
This modification allows the documentation of `objects` that are maps. For example when we return a maping of IDs to entities:
```json
{
    "included": {
        "users": {
             "21" : {"name": "Bar" },
             "25" : {"name": "Foo"}
         }
    }
}
```

here is one way to support the mapping  `{"[id]" : { "id": "[id]", "name": "foo"}, .. }`, in JSON Schema , and provide the information of the mapped type with `additionalProperties` :
> If additionalProperties is an object, that object is a schema that will be used to validate any additional properties not listed in properties

(see: http://json-schema.org/understanding-json-schema/reference/object.html#properties ), and  in the OpenAPI Spec  that is supported ( https://swagger.io/specification/#schemaObject ) : 
> additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a Schema Object and not a standard JSON Schema. Consistent with JSON Schema, additionalProperties defaults to true.