### PR TITLE
fix: arrays of objects in query not allowed

### DIFF
--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -285,12 +285,23 @@ func write(outFormat string, w io.Writer, prog *docparse.Program) error {
 					// (we can not have a field without schema nor type )
 					queryType = "string"
 				}
+
+				items := schema.Items
+				if items != nil && len(items.Reference) != 0 {
+					// in swagger 2.0, arrays in the query can only
+					// contain basic type, so, if it holds a reference
+					// we change it to a string
+					items = &docparse.Schema{
+						Type: "string",
+					}
+				}
+
 				op.Parameters = append(op.Parameters, Parameter{
 					Name:        f.Name,
 					In:          "query",
 					Description: schema.Description,
 					Type:        queryType,
-					Items:       schema.Items,
+					Items:       items,
 					Required:    len(schema.Required) > 0,
 					Readonly:    schema.Readonly,
 					Enum:        schema.Enum,


### PR DESCRIPTION
Kommentaar creates Swagger 2.0 spec. From the official documentation [Describing Parameters](https://swagger.io/docs/specification/2-0/describing-parameters/#query-parameters):

> Query parameters only support primitive types. You can have an array, but the items must be a primitive value type. Objects are not supported.

So, just for the query params, (in line 260 of `openapi2.go`), when we have a `items` field that is a reference to another object definition, we map it to a `string`. 

(In OpenAPI 3.0 there is keyword `content` , that allows for complex objects in the query param https://swagger.io/docs/specification/describing-parameters/#schema-vs-content , but that would mean upgrade the spec version generation)