### PR TITLE
Remove definitions that have no references

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Configuration
 Kommentaar can be configured with a configuration file; see
 [`config.example`](config.example) for the documentation.
 
+Running Tests
+-------------
+
+`GO111MODULE=off ./bin/test ./...`
+
 Motivation and rationale
 ------------------------
 

--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -348,9 +348,12 @@ start:
 		// Deal with array.
 		// TODO: don't do this inline but at the end. Reason it doesn't work not
 		// is because we always use GetReference().
-		ts, _, _, err := findType(ref.File, pkg, name.Name)
+		ts, _, importPath, err := findType(ref.File, pkg, name.Name)
 		if err != nil {
 			return nil, err
+		}
+		if !strings.HasSuffix(importPath, pkg) { // import alias
+			pkg = importPath
 		}
 
 		switch resolvType := ts.Type.(type) {

--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -535,6 +535,15 @@ arrayStart:
 		pkg = pkgSel.Name
 		name = typ.Sel
 
+		// handle import aliases
+		_, _, importPath, err := findType(ref.File, pkg, name.Name)
+		if err != nil {
+			return fmt.Errorf("resolveArray: findType: %v", err)
+		}
+		if !strings.HasSuffix(importPath, pkg) {
+			pkg = importPath
+		}
+
 	default:
 		return fmt.Errorf("fieldToSchema: unknown array type: %T", typ)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -36,9 +36,6 @@ func TestOpenAPI2(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if tt.Name() != "package-alias" {
-			continue
-		}
 		t.Run(tt.Name(), func(t *testing.T) {
 			path := "./testdata/openapi2/src/" + tt.Name()
 

--- a/main_test.go
+++ b/main_test.go
@@ -84,7 +84,8 @@ func TestOpenAPI2(t *testing.T) {
 
 			d := diff.TextDiff(string(want), out)
 			if d != "" {
-				t.Fatalf("wrong output\n%v", d)
+				t.Errorf("incorrect output: \n%s", out)
+				t.Fatalf("diff\n%v", d)
 			}
 
 			if len(wantJSON) > 1 {

--- a/main_test.go
+++ b/main_test.go
@@ -36,6 +36,9 @@ func TestOpenAPI2(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		if tt.Name() != "package-alias" {
+			continue
+		}
 		t.Run(tt.Name(), func(t *testing.T) {
 			path := "./testdata/openapi2/src/" + tt.Name()
 

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -449,13 +449,8 @@ func write(outFormat string, w io.Writer, prog *docparse.Program) error {
 		if v.Schema == nil {
 			return fmt.Errorf("schema is nil for %q", k)
 		}
-		switch v.Context {
-		case "form", "query", "path":
-			// Nothing, this will be inline in the operation.
-		default:
-			prefixPropertyReferences(v.Schema.Properties, ref)
-			out.Definitions[k] = *v.Schema
-		}
+		prefixPropertyReferences(v.Schema.Properties, ref)
+		out.Definitions[k] = *v.Schema
 	}
 	// Remove unreferenced definitions.
 	for k := range out.Definitions {

--- a/testdata/openapi2/src/embedded-sometimes/in.go
+++ b/testdata/openapi2/src/embedded-sometimes/in.go
@@ -1,0 +1,21 @@
+package embedded_sometimes
+
+// RequestObj is a request object.
+type RequestObj struct {
+	CommonProperties // embedded here
+}
+
+// AnObject is another object.
+type AnObject struct {
+	Properties CommonProperties // named here
+}
+
+// CommonProperties has common properties.
+type CommonProperties struct {
+	Field string
+}
+
+// POST /foo/{id} foobar
+//
+// Request body (application/json): RequestObj
+// Response 200 (application/json): AnObject

--- a/testdata/openapi2/src/embedded-sometimes/want.yaml
+++ b/testdata/openapi2/src/embedded-sometimes/want.yaml
@@ -1,0 +1,57 @@
+swagger: "2.0"
+info:
+  title: x
+  version: x
+consumes:
+- application/json
+produces:
+- application/json
+tags:
+- name: foobar
+paths:
+  /foo/{id}:
+    post:
+      operationId: POST_foo_{id}
+      tags:
+      - foobar
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - name: id
+        in: path
+        type: integer
+        required: true
+      - name: embedded-sometimes.RequestObj
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/embedded-sometimes.RequestObj'
+      responses:
+        200:
+          description: 200 OK
+          schema:
+            $ref: '#/definitions/embedded-sometimes.AnObject'
+definitions:
+  embedded-sometimes.AnObject:
+    title: AnObject
+    description: AnObject is another object.
+    type: object
+    properties:
+      Properties:
+        $ref: '#/definitions/embedded-sometimes.CommonProperties'
+  embedded-sometimes.CommonProperties:
+    title: CommonProperties
+    description: CommonProperties has common properties.
+    type: object
+    properties:
+      Field:
+        type: string
+  embedded-sometimes.RequestObj:
+    title: RequestObj
+    description: RequestObj is a request object.
+    type: object
+    properties:
+      Field:
+        type: string

--- a/testdata/openapi2/src/field-whitelist/want.yaml
+++ b/testdata/openapi2/src/field-whitelist/want.yaml
@@ -18,15 +18,6 @@ paths:
           schema:
             $ref: '#/definitions/field-whitelist.SecondStruct'
 definitions:
-  field-whitelist.FirstStruct:
-    title: FirstStruct
-    description: FirstStruct docs
-    type: object
-    properties:
-      field_one:
-        type: string
-      field_two:
-        type: string
   field-whitelist.SecondStruct:
     title: SecondStruct
     description: SecondStruct docs

--- a/testdata/openapi2/src/package-alias/in.go
+++ b/testdata/openapi2/src/package-alias/in.go
@@ -15,7 +15,8 @@ type OtherThing struct {
 }
 
 type ErrorResponse struct {
-	Errors []alias.Error
+	Errors  []alias.Error
+	PErrors []*alias.Error
 }
 
 // POST /foo/{id} foobar

--- a/testdata/openapi2/src/package-alias/in.go
+++ b/testdata/openapi2/src/package-alias/in.go
@@ -14,9 +14,14 @@ type OtherThing struct {
 	Something alias.Something
 }
 
+type ErrorResponse struct {
+	Errors []alias.Error
+}
+
 // POST /foo/{id} foobar
 //
 // Request body (application/json): OtherThing
 // Form: alias.Something
 // Response 200: otherpkg.Something
-// Response 400: alias.Something
+// Response 201: alias.Something
+// Response 400: ErrorResponse

--- a/testdata/openapi2/src/package-alias/in.go
+++ b/testdata/openapi2/src/package-alias/in.go
@@ -1,0 +1,22 @@
+package package_alias
+
+import alias "package-alias/otherpkg"
+
+/*
+   Testing here that import aliases work as expected, we can
+   refer to it via the alias or its actual package name and it
+   will end up in the response as otherpkg.Something rather than
+   alias.Something
+*/
+
+// OtherThing is another thing.
+type OtherThing struct {
+	Something alias.Something
+}
+
+// POST /foo/{id} foobar
+//
+// Request body (application/json): OtherThing
+// Form: alias.Something
+// Response 200: otherpkg.Something
+// Response 400: alias.Something

--- a/testdata/openapi2/src/package-alias/otherpkg/in.go
+++ b/testdata/openapi2/src/package-alias/otherpkg/in.go
@@ -1,0 +1,6 @@
+package otherpkg
+
+// Something is something.
+type Something struct {
+	Field string
+}

--- a/testdata/openapi2/src/package-alias/otherpkg/in.go
+++ b/testdata/openapi2/src/package-alias/otherpkg/in.go
@@ -4,3 +4,7 @@ package otherpkg
 type Something struct {
 	Field string
 }
+
+type Error struct {
+	Message string
+}

--- a/testdata/openapi2/src/package-alias/want.yaml
+++ b/testdata/openapi2/src/package-alias/want.yaml
@@ -1,0 +1,58 @@
+swagger: "2.0"
+info:
+  title: x
+  version: x
+consumes:
+- application/json
+produces:
+- application/json
+tags:
+- name: foobar
+paths:
+  /foo/{id}:
+    post:
+      operationId: POST_foo_{id}
+      tags:
+      - foobar
+      consumes:
+      - application/x-www-form-urlencoded
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - name: Field
+        in: formData
+        type: string
+      - name: package-alias.OtherThing
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/package-alias.OtherThing'
+      - name: id
+        in: path
+        type: integer
+        required: true
+      responses:
+        200:
+          description: 200 OK
+          schema:
+            $ref: '#/definitions/otherpkg.Something'
+        400:
+          description: 400 Bad Request
+          schema:
+            $ref: '#/definitions/otherpkg.Something'
+definitions:
+  otherpkg.Something:
+    title: Something
+    description: Something is something.
+    type: object
+    properties:
+      Field:
+        type: string
+  package-alias.OtherThing:
+    title: OtherThing
+    description: OtherThing is another thing.
+    type: object
+    properties:
+      Something:
+        $ref: '#/definitions/otherpkg.Something'

--- a/testdata/openapi2/src/package-alias/want.yaml
+++ b/testdata/openapi2/src/package-alias/want.yaml
@@ -37,10 +37,14 @@ paths:
           description: 200 OK
           schema:
             $ref: '#/definitions/otherpkg.Something'
+        201:
+          description: 201 Created
+          schema:
+            $ref: '#/definitions/otherpkg.Something'
         400:
           description: 400 Bad Request
           schema:
-            $ref: '#/definitions/otherpkg.Something'
+            $ref: '#/definitions/package-alias.ErrorResponse'
 definitions:
   otherpkg.Something:
     title: Something
@@ -49,6 +53,14 @@ definitions:
     properties:
       Field:
         type: string
+  package-alias.ErrorResponse:
+    title: ErrorResponse
+    type: object
+    properties:
+      Errors:
+        type: array
+        items:
+          $ref: '#/definitions/otherpkg.Error'
   package-alias.OtherThing:
     title: OtherThing
     description: OtherThing is another thing.

--- a/testdata/openapi2/src/package-alias/want.yaml
+++ b/testdata/openapi2/src/package-alias/want.yaml
@@ -46,6 +46,12 @@ paths:
           schema:
             $ref: '#/definitions/package-alias.ErrorResponse'
 definitions:
+  otherpkg.Error:
+    title: Error
+    type: object
+    properties:
+      Message:
+        type: string
   otherpkg.Something:
     title: Something
     description: Something is something.
@@ -58,6 +64,10 @@ definitions:
     type: object
     properties:
       Errors:
+        type: array
+        items:
+          $ref: '#/definitions/otherpkg.Error'
+      PErrors:
         type: array
         items:
           $ref: '#/definitions/otherpkg.Error'

--- a/testdata/openapi2/src/param-schema/in.go
+++ b/testdata/openapi2/src/param-schema/in.go
@@ -2,9 +2,6 @@ package path
 
 import "encoding/json"
 
-// Ideally we don't want dontInclude in the output, as it's not referenced
-// anywhere; but that's a bit hard with the current design.
-
 // I've got a title already
 type dontInclude struct {
 	DontIncludeThis string

--- a/testdata/openapi2/src/param-schema/want.yaml
+++ b/testdata/openapi2/src/param-schema/want.yaml
@@ -50,10 +50,3 @@ definitions:
             type: string
           other:
             type: string
-  param-schema.dontInclude:
-    title: dontInclude
-    description: I've got a title already
-    type: object
-    properties:
-      DontIncludeThis:
-        type: string


### PR DESCRIPTION
This was removing them from definitions based on if it was embedded in another
struct, but didn't handle the case if it was embedded one place and named in
another.

Fixes #79