### PR TITLE
Fix imported ref directives

### DIFF
--- a/docparse/docparse.go
+++ b/docparse/docparse.go
@@ -351,7 +351,7 @@ func parseComment(prog *Program, comment, pkgPath, filePath string) ([]*Endpoint
 
 	// expand variables
 	var expandErr error
-	e.Info = regexp.MustCompile(`(\\)?\$[a-zA-Z0-9\.]+`).
+	e.Info = regexp.MustCompile(`(\\)?\$[a-zA-Z0-9\.\/]+`).
 		ReplaceAllStringFunc(e.Info, func(m string) string {
 			if strings.HasPrefix(m, `\`) { // escaped
 				return m[1:] // strip "$"

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+arp242.net/sconfig v0.0.0-20180901013357-c014d3b7a101 h1:V6CYq+es2ncUeJ2jzJxWVviAs7iNW/jvPb4+3LHOXsE=
+arp242.net/sconfig v0.0.0-20180901013357-c014d3b7a101/go.mod h1:s7teWAlHUlC2xRICC2FKERk6kQBI9lREHKRfWIWF+lA=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
+github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/teamwork/test v0.0.0-20181126061546-2ff8918eb6a4 h1:/ujiGN1Gf1yBNvRoXSn/c24mbyjQN+r3nXOKLXfUt+A=
+github.com/teamwork/test v0.0.0-20181126061546-2ff8918eb6a4/go.mod h1:TIbx7tx6WHBjQeLRM4eWQZBL7kmBZ7/KI4x4v7Y5YmA=
+github.com/teamwork/utils v0.0.0-20190114034940-d6a1f27ce92c h1:5/hkqtufOyLP25taIlo7BX9kLhw21unfjjdrOlwvFJk=
+github.com/teamwork/utils v0.0.0-20190114034940-d6a1f27ce92c/go.mod h1:rmPaJUVv426LGg3QR31m1N0bfpCdCVyh3dCWsJTQeDA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Imported reference directives where not being matched correctly, as shown in the [syntax doc](https://github.com/Teamwork/kommentaar/blob/master/doc/syntax.markdown#reference-directives).

E.g
```
$github.com/myorg/mypkg.t
```
would be matched as
```
$github.com
```
and then fail to import