### PR TITLE
Fix: Inconsistent sorting given same name different 'in'

### DIFF
--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -385,8 +385,12 @@ func write(outFormat string, w io.Writer, prog *docparse.Program) error {
 		// TODO: preserve order in which they were defined in the struct, but
 		// for now sort it like this so the output is stable.
 		sort.Slice(op.Parameters, func(i, j int) bool {
-			left := op.Parameters[i].In + op.Parameters[i].Type + op.Parameters[i].Name
-			right := op.Parameters[j].In + op.Parameters[j].Type + op.Parameters[j].Name
+			left := op.Parameters[i].Type + op.Parameters[i].Name
+			right := op.Parameters[j].Type + op.Parameters[j].Name
+			if left == right {
+				specificOrder := map[string]int64{"path": 0, "query": 1, "formData": 2, "body": 3}
+				return specificOrder[op.Parameters[i].In] < specificOrder[op.Parameters[j].In]
+			}
 			return left > right
 		})
 

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -385,7 +385,9 @@ func write(outFormat string, w io.Writer, prog *docparse.Program) error {
 		// TODO: preserve order in which they were defined in the struct, but
 		// for now sort it like this so the output is stable.
 		sort.Slice(op.Parameters, func(i, j int) bool {
-			return op.Parameters[i].Type+op.Parameters[i].Name > op.Parameters[j].Type+op.Parameters[j].Name
+			left := op.Parameters[i].In + op.Parameters[i].Type + op.Parameters[i].Name
+			right := op.Parameters[j].In + op.Parameters[j].Type + op.Parameters[j].Name
+			return left > right
 		})
 
 		for code, resp := range e.Responses {


### PR DESCRIPTION
Handles sort inconsistencies when a path and query exist with the same name+type.

Note: swagger doesn't actually care about what order `"in"` is in, I just didn't feel like updating a whole bunch of test expected outputs, and this was the order the code was already using for non-duplicates.

Otherwise I could have just made it In + Type + Name > In + Type + Name