### PR TITLE
Dev: Upgrade Go compiler

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,9 +7,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: false
+
       - name: Lint
         uses: golangci/golangci-lint-action@v4
         with:
+          version: v1.54
           only-new-issues: true
 
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           only-new-issues: true
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
 
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.20"
+        go-version: "1.22"
 
     - uses: actions/checkout@v4
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine
+FROM golang:1.22-alpine
 
 VOLUME /code
 VOLUME /config

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/teamwork/kommentaar
 
-go 1.20
+go 1.22
 
 require (
 	github.com/imdario/mergo v0.3.13

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/teamwork/utils/v2 v2.0.1/go.mod h1:a2xpeXNKXYgxY/3UMMXhBy5SJ03dT7xRC0
 golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
 golang.org/x/mod v0.10.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=


### PR DESCRIPTION
This is required to generate docs using the latest library-type comments correctly.

For example, the doc [here](https://github.com/golang/go/blob/go1.22.1/src/time/zoneinfo.go?name=release#L20-L22) will only be added to `time.Location` type if the Kommentaar container is using the latest compiler version.

Related to:
https://github.com/Teamwork/projectsapigo/pull/9197
https://github.com/Teamwork/projectsapigo/actions/runs/8279682137/job/22655306455?pr=9197