### PR TITLE
Log empty tags

### DIFF
--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -66,6 +66,7 @@ func structToSchema(prog *Program, name, tagName string, ref Reference) (*Schema
 			continue
 		}
 		if name == "" {
+			fmt.Fprintf(os.Stderr, "empty `%s` tag for %s. tags value: %s\n", tagName, schema.Title, p.KindField.Tag.Value)
 			name = p.Name
 		}
 


### PR DESCRIPTION
we have an issue where properties are randomly switch case.
I think it's coming from the tag missing somehow.