### PR TITLE
Add support for enums w/o needing to manually specify variations

### DIFF
--- a/docparse/jsonschema_test.go
+++ b/docparse/jsonschema_test.go
@@ -22,6 +22,8 @@ func TestFieldToProperty(t *testing.T) {
 		"sliceP":    {Type: "array", Items: &Schema{Type: "string"}},
 		"cstr":      {Type: "string"},
 		"cstrP":     {Type: "string"},
+		"enumStr":   {Type: "string", Enum: []string{"a", "b", "c"}},
+		"enumsStr":  {Type: "array", Items: &Schema{Type: "string", Enum: []string{"a", "b", "c"}}},
 		"bar":       {Reference: "a.bar"},
 		"barP":      {Reference: "a.bar"},
 		"pkg":       {Reference: "mail.Address"},

--- a/docparse/testdata/src/a/a.go
+++ b/docparse/testdata/src/a/a.go
@@ -11,17 +11,21 @@ import "net/mail"
 type foo struct {
 	// Documented str field.
 	// Newline.
-	str       string
-	byt       []byte
-	r         rune
-	b         bool // Inline docs.
-	fl        float64
-	err       error
-	strP      *string
-	slice     []string
-	sliceP    []*string
-	cstr      customStr
-	cstrP     *customStr
+	str    string
+	byt    []byte
+	r      rune
+	b      bool // Inline docs.
+	fl     float64
+	err    error
+	strP   *string
+	slice  []string
+	sliceP []*string
+	cstr   customStr
+	cstrP  *customStr
+	// {enum}
+	enumStr customStr
+	// {enum}
+	enumsStr  []customStr
 	bar       bar
 	barP      *bar
 	pkg       mail.Address
@@ -41,7 +45,15 @@ type nested struct {
 	deeper refAnother
 }
 
+type customStrs []customStr
+
 type customStr string
+
+const (
+	customStrA customStr = "a"
+	customStrB customStr = "b"
+	customStrC customStr = "c"
+)
 
 // Document me bar!
 type bar struct {


### PR DESCRIPTION
Solves https://github.com/Teamwork/kommentaar/issues/89

It will only attempt to figure out the variations if type:"enum" is specified and len(enums) is 0.
i.e. if someone uses the {enum} comment, or, for some reason, {enum: }.

The only edge cases I can think of here are in our own code, where we sometimes might not want "all" or "" exposed as enum options in the API even though they technically exist. In which case we'd still need to manually specify all the fields like we were doing prior to now.