### PR TITLE
Fix: Generics - Upgrade dependency to correctly handle new AST types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 require (
 	github.com/imdario/mergo v0.3.13
 	github.com/teamwork/test v0.0.0-20200108114543-02621bae84ad
-	github.com/teamwork/utils/v2 v2.0.1
+	github.com/teamwork/utils/v2 v2.2.5
 	golang.org/x/text v0.9.0
 	golang.org/x/tools v0.8.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/teamwork/test v0.0.0-20200108114543-02621bae84ad h1:25sEr0awm0ZPancg5
 github.com/teamwork/test v0.0.0-20200108114543-02621bae84ad/go.mod h1:TIbx7tx6WHBjQeLRM4eWQZBL7kmBZ7/KI4x4v7Y5YmA=
 github.com/teamwork/utils v1.0.1-0.20230426101410-71bb0b003654 h1:5wExUHbkpsRWC1BiavI1nlvc12KFrF/EIn1d7WEbLO8=
 github.com/teamwork/utils v1.0.1-0.20230426101410-71bb0b003654/go.mod h1:9GJXyhNsP6vGDt1oNW1Rt/Aj4+pWeT8BuUHFOF7lyrw=
-github.com/teamwork/utils/v2 v2.0.1 h1:+tSO+Ll4XBMVzeTzmAtM5dswzSF0kb/d9dFdRXVMsFg=
-github.com/teamwork/utils/v2 v2.0.1/go.mod h1:a2xpeXNKXYgxY/3UMMXhBy5SJ03dT7xRC0cNjwtkkc4=
+github.com/teamwork/utils/v2 v2.2.5 h1:IE692P67acrLtjpBMzvB1S7cxjtphSDJ3VGl01lNxLE=
+github.com/teamwork/utils/v2 v2.2.5/go.mod h1:a2xpeXNKXYgxY/3UMMXhBy5SJ03dT7xRC0cNjwtkkc4=
 golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
 golang.org/x/mod v0.10.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=

--- a/vendor/github.com/teamwork/utils/v2/goutil/goutil.go
+++ b/vendor/github.com/teamwork/utils/v2/goutil/goutil.go
@@ -1,4 +1,6 @@
 // Package goutil provides functions to work with Go source files.
+//
+//nolint:staticcheck
 package goutil // import "github.com/teamwork/utils/v2/goutil"
 
 import (
@@ -96,7 +98,7 @@ func ResolveWildcard(path string, mode build.ImportMode) ([]*build.Package, erro
 
 	// Gather a list of directories with *.go files.
 	goDirs := make(map[string]struct{})
-	err = filepath.Walk(root.Dir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(root.Dir, func(path string, info os.FileInfo, _ error) error {
 		if !strings.HasSuffix(path, ".go") || info.IsDir() || strings.Contains(path, "/vendor/") {
 			return nil
 		}
@@ -253,6 +255,12 @@ start:
 		return t.Name
 	case *ast.SelectorExpr:
 		return t.Sel.Name
+	case *ast.IndexExpr:
+		f = t.X
+		goto start
+	case *ast.IndexListExpr:
+		f = t.X
+		goto start
 	default:
 		panic(fmt.Sprintf("can't get name for %#v", f))
 	}

--- a/vendor/github.com/teamwork/utils/v2/sliceutil/compatibility.go
+++ b/vendor/github.com/teamwork/utils/v2/sliceutil/compatibility.go
@@ -1,0 +1,99 @@
+package sliceutil
+
+// JoinInt see Join
+//
+// Deprecated: use Join
+func JoinInt(ints []int64) string {
+	return Join(ints)
+}
+
+// UniqInt64 see Unique
+//
+// Deprecated: use Unique
+func UniqInt64(list []int64) []int64 {
+	return Unique(list)
+}
+
+// UniqString see Unique
+//
+// Deprecated: use Unique
+func UniqString(list []string) []string {
+	return Unique(list)
+}
+
+// UniqueMergeSlices see MergeUnique
+//
+// Deprecated: use MergeUnique
+func UniqueMergeSlices(s [][]int64) (result []int64) {
+	return MergeUnique(s)
+}
+
+// InStringSlice see Contains
+//
+// Deprecated: use Contains
+func InStringSlice(list []string, str string) bool {
+	return Contains(list, str)
+}
+
+// InIntSlice see Contains
+//
+// Deprecated: use Contains
+func InIntSlice(list []int, i int) bool {
+	return Contains(list, i)
+}
+
+// InInt64Slice see Contains
+//
+// Deprecated: use Contains
+func InInt64Slice(list []int64, i int64) bool {
+	return Contains(list, i)
+}
+
+// RepeatString see Repeat
+//
+// Deprecated: use Repeat
+func RepeatString(s string, n int) (r []string) {
+	return Repeat(s, n)
+}
+
+// ChooseString see Choose
+//
+// Deprecated: use Choose
+func ChooseString(l []string) string {
+	return Choose(l)
+}
+
+// FilterString see Filter
+//
+// Deprecated: use Filter
+func FilterString(list []string, fun func(string) bool) []string {
+	return Filter(list, fun)
+}
+
+// RemoveString see Remove
+//
+// Deprecated: use Remove
+func RemoveString(list []string, s string) (out []string) {
+	return Remove(list, s)
+}
+
+// FilterStringEmpty see FilterEmpty
+//
+// Deprecated: use FilterEmpty
+func FilterStringEmpty(e string) bool {
+	return FilterEmpty(e)
+}
+
+// FilterInt see Filter
+//
+// Deprecated: use Filter
+func FilterInt(list []int64, fun func(int64) bool) []int64 {
+	return Filter(list, fun)
+}
+
+// StringMap see Map
+//
+// Deprecated: use Map
+func StringMap(list []string, f func(string) string) []string {
+	return Map(list, f)
+}

--- a/vendor/github.com/teamwork/utils/v2/sliceutil/sliceutil.go
+++ b/vendor/github.com/teamwork/utils/v2/sliceutil/sliceutil.go
@@ -18,12 +18,17 @@ import (
 // Join converts a slice of T to a comma separated string. Useful for
 // inserting into a query without the option of parameterization.
 func Join[T any](tt []T) string {
-	var str []string
-	for _, t := range tt {
-		str = append(str, fmt.Sprintf("%v", t))
+	return JoinWith(tt, ", ")
+}
+
+// JoinWith converts a slice of T to a string using the provided delim.
+func JoinWith[T any](tt []T, delim string) string {
+	str := make([]string, len(tt))
+	for i, t := range tt {
+		str[i] = fmt.Sprintf("%v", t)
 	}
 
-	return strings.Join(str, ", ")
+	return strings.Join(str, delim)
 }
 
 // Unique removes duplicate entries from a list. The list does not have to be sorted.
@@ -185,4 +190,23 @@ func InterfaceSliceTo(src []interface{}, dst interface{}) interface{} {
 	}
 
 	return dstV.Interface()
+}
+
+// ToAnySlice converts a slice of T to a slice of any.
+func ToAnySlice[T any](tt []T) []any {
+	ret := make([]any, len(tt))
+	for i, t := range tt {
+		ret[i] = t
+	}
+	return ret
+}
+
+// Values returns a list of items extracted from T, see test file for example
+func Values[T comparable, N any](tt []T, fn func(T) N) []N {
+	ret := make([]N, len(tt))
+	for i, t := range tt {
+		ret[i] = fn(t)
+	}
+
+	return ret
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,7 +15,7 @@ github.com/teamwork/test/diff
 ## explicit; go 1.20
 github.com/teamwork/utils/jsonutil
 github.com/teamwork/utils/stringutil
-# github.com/teamwork/utils/v2 v2.0.1
+# github.com/teamwork/utils/v2 v2.2.5
 ## explicit; go 1.20
 github.com/teamwork/utils/v2/goutil
 github.com/teamwork/utils/v2/sliceutil


### PR DESCRIPTION
Fix an error raised when trying to extract a tag name from a generic type.

```
panic: can't get name for &ast.IndexExpr{X:(*ast.SelectorExpr)(0x40001cb6b0), Lbrack:4887, Index:(*ast.SelectorExpr)(0x40001cb6c8), Rbrack:4914}

goroutine 1 [running]:
github.com/teamwork/kommentaar/vendor/github.com/teamwork/utils/v2/goutil.getEmbedName({0x642200?, 0x400018c1e0?})
	/go/src/github.com/teamwork/kommentaar/vendor/github.com/teamwork/utils/v2/goutil/goutil.go:257 +0x108
github.com/teamwork/kommentaar/vendor/github.com/teamwork/utils/v2/goutil.TagName(0x4000001d40?, {0x559e40?, 0x5?})
	/go/src/github.com/teamwork/kommentaar/vendor/github.com/teamwork/utils/v2/goutil/goutil.go:224 +0x44
github.com/teamwork/kommentaar/docparse.GetReference(0x4000001d40, {0x559e40, 0x5}, 0x0, {0x40006f813a, 0x11}, {0x40001706e0, 0x50})
	/go/src/github.com/teamwork/kommentaar/docparse/find.go:440 +0x1088
github.com/teamwork/kommentaar/docparse.parseRefValue(0x4000001d40, {0x559e40, 0x5}, {0x40006f813a, 0x11}, {0x40001706e0, 0x50})
	/go/src/github.com/teamwork/kommentaar/docparse/docparse.go:501 +0xc0
github.com/teamwork/kommentaar/docparse.parseComment(0x4000001d40, {0x40006f8000, 0x1c1}, {0x0?, 0x0?}, {0x40001706e0, 0x50})
	/go/src/github.com/teamwork/kommentaar/docparse/docparse.go:274 +0x570
github.com/teamwork/kommentaar/docparse.FindComments({0x63e820, 0x400004a060}, 0x4000001d40)
	/go/src/github.com/teamwork/kommentaar/docparse/find.go:49 +0x448
main.start()
	/go/src/github.com/teamwork/kommentaar/main.go:91 +0x4f0
main.main()
	/go/src/github.com/teamwork/kommentaar/main.go:23 +0x48
```

Related to:
https://github.com/Teamwork/utils/pull/85