### PR TITLE
Fix: Generics > Cross-package generics

### DIFF
--- a/docparse/jsonschema.go
+++ b/docparse/jsonschema.go
@@ -295,6 +295,16 @@ start:
 				// Primitive type arg (e.g. string, int): set directly.
 				mappedType = "generics"
 				p.Type = primitiveType
+			} else if dotIdx := strings.LastIndex(resolvedName, "."); dotIdx >= 0 {
+				// Cross-package type arg stored as "fullPkgPath.TypeName":
+				// reconstruct as SelectorExpr and re-dispatch so that the
+				// package is resolved correctly instead of falling back to the
+				// generic type's own package.
+				sw = &ast.SelectorExpr{
+					X:   &ast.Ident{Name: resolvedName[:dotIdx]},
+					Sel: &ast.Ident{Name: resolvedName[dotIdx+1:]},
+				}
+				goto start
 			} else {
 				// Non-primitive type arg: replace the type parameter ident
 				// with the resolved name and let the normal canonicalType /
@@ -562,11 +572,22 @@ func fillGenericsSchema(
 				len(genericsTemplateIDs), len(indices))
 		}
 		for i := 0; i < len(indices); i++ {
-			arg, _, err := findTypeIdent(indices[i], ref.Package)
+			arg, argPkg, err := findTypeIdent(indices[i], ref.Package)
 			if err != nil {
 				return fmt.Errorf("cannot find generic type argument: %v", err)
 			}
-			generics[genericsTemplateIDs[i]] = arg.Name
+			if argPkg != ref.Package {
+				// Cross-package type argument: resolve the import alias to the
+				// full package path so it can be looked up unambiguously later,
+				// regardless of which file provides the resolution context.
+				resolvedArgPkg, _, resolveErr := resolvePackage(ref.File, argPkg)
+				if resolveErr != nil {
+					return fmt.Errorf("cannot resolve package %q for generic type argument: %v", argPkg, resolveErr)
+				}
+				generics[genericsTemplateIDs[i]] = resolvedArgPkg + "." + arg.Name
+			} else {
+				generics[genericsTemplateIDs[i]] = arg.Name
+			}
 		}
 	}
 

--- a/testdata/openapi2/src/generics-cross-pkg-third/enumpkg/enumpkg.go
+++ b/testdata/openapi2/src/generics-cross-pkg-third/enumpkg/enumpkg.go
@@ -1,0 +1,4 @@
+package enumpkg
+
+// MetricType is an enum type from a third package.
+type MetricType string

--- a/testdata/openapi2/src/generics-cross-pkg-third/genpkg/genpkg.go
+++ b/testdata/openapi2/src/generics-cross-pkg-third/genpkg/genpkg.go
@@ -1,0 +1,9 @@
+package genpkg
+
+// Wrapper is a generic struct defined in a separate package.
+type Wrapper[T any] struct {
+	// Value holds the generic field.
+	Value T
+	// Count is a fixed field.
+	Count int
+}

--- a/testdata/openapi2/src/generics-cross-pkg-third/in.go
+++ b/testdata/openapi2/src/generics-cross-pkg-third/in.go
@@ -1,0 +1,16 @@
+package generics_cross_pkg_third
+
+import (
+	enumpkg "generics-cross-pkg-third/enumpkg"
+	genpkg "generics-cross-pkg-third/genpkg"
+)
+
+type reqRef struct {
+	// Metric documents a generic with a type arg from a third package.
+	Metric genpkg.Wrapper[enumpkg.MetricType]
+}
+
+// POST /path
+//
+// Request body: reqRef
+// Response 200: {empty}

--- a/testdata/openapi2/src/generics-cross-pkg-third/want.yaml
+++ b/testdata/openapi2/src/generics-cross-pkg-third/want.yaml
@@ -1,0 +1,40 @@
+swagger: "2.0"
+info:
+  title: x
+  version: x
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /path:
+    post:
+      operationId: POST_path
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: generics-cross-pkg-third.reqRef
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/generics-cross-pkg-third.reqRef'
+      responses:
+        200:
+          description: 200 OK (no data)
+definitions:
+  generics-cross-pkg-third.reqRef:
+    title: reqRef
+    type: object
+    properties:
+      Metric:
+        description: Metric documents a generic with a type arg from a third package.
+        type: object
+        properties:
+          Count:
+            description: Count is a fixed field.
+            type: integer
+          Value:
+            description: Value holds the generic field.
+            type: string


### PR DESCRIPTION
The previous PR (#102) added partial support for generics, but the tool would fail if a generic struct was defined in package A and when instantiated, it was done so using a type from a different package: `SomeField *a.Field[b.Other]`

This PR addresses that by adding full support for generics (I hope!)