### PR TITLE
Dev: Preinstall kommentaar in final Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
-FROM golang:1.22-alpine
+FROM golang:1.26-alpine AS builder
+
+COPY . /go/src/github.com/teamwork/kommentaar
+
+RUN cd /go/src/github.com/teamwork/kommentaar && \
+    GO111MODULE=off go install .
+
+FROM golang:1.26-alpine
 
 VOLUME /code
 VOLUME /config
 VOLUME /output
 
-COPY . /go/src/github.com/teamwork/kommentaar
+COPY --from=builder /go/bin/kommentaar /go/bin/kommentaar
+COPY run.sh /run.sh
 COPY config.example /config/kommentaar.conf
 
-CMD ["/go/src/github.com/teamwork/kommentaar/run.sh"]
+CMD ["/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,8 @@ fi
 
 echo "Running kommentaar for $MODULE_PATH"
 
-cp -r /code /go/src/$MODULE_PATH
+mkdir -p /go/src/$MODULE_PATH
+cp -r /code/. /go/src/$MODULE_PATH
 
 config=/config/kommentaar.conf
 # check if we should override with env var
@@ -37,7 +38,6 @@ echo "Kommentaar will be executed against $exec_path"
 
 export GOPATH=/go
 export GO111MODULE=off
-go install /go/src/github.com/teamwork/kommentaar
 
 cd /go/src/$MODULE_PATH
 /go/bin/kommentaar -config $config -output $output $exec_path > /output/swagger.$output_ext


### PR DESCRIPTION
Preinstall kommentaar in the final Docker image to avoid reinstalling it every time the container starts up. This should make the image slightly faster.

In order to make the image as small as possible, I added a two-stage build. Both contain the `go` toolchain as the tool needs it at runtime, but now the final image will not contain the source code and git contents, so it should be a bit lighter.