### PR TITLE
Honor json:"-" on embedded fields during initial field walk

### DIFF
--- a/docparse/docparse_test.go
+++ b/docparse/docparse_test.go
@@ -565,6 +565,38 @@ func TestGetReference(t *testing.T) {
 	}
 }
 
+// Regression: an embedded qualified pointer type tagged `json:"-"` (e.g.
+// `*mail.Address `json:"-"``) previously caused a nil-pointer panic because
+// the first field-walk pass tried to resolve the embed before checking the
+// JSON tag. The fix is to honor `json:"-"` in that pass too. We also
+// verify the embed is absent from the resulting Reference.Fields and the
+// referenced external type is not pulled into prog.References.
+func TestGetReference_EmbedJSONDash(t *testing.T) {
+	prog := NewProgram(false)
+	prog.Config.StructTag = "json"
+	out, err := GetReference(prog, "req", false, "testEmbedJSONDash", ".")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out == nil {
+		t.Fatal("nil reference")
+	}
+
+	var names []string
+	for _, f := range out.Fields {
+		names = append(names, f.Name)
+	}
+	wantFields := []string{"ID"}
+	if !reflect.DeepEqual(names, wantFields) {
+		t.Errorf("fields: got %v, want %v", names, wantFields)
+	}
+
+	if _, ok := prog.References["mail.Address"]; ok {
+		t.Errorf("mail.Address was resolved despite json:\"-\" on embed")
+	}
+}
+
 func TestParseResponse(t *testing.T) {
 	tests := []struct {
 		in       string

--- a/docparse/docparse_test.go
+++ b/docparse/docparse_test.go
@@ -565,12 +565,13 @@ func TestGetReference(t *testing.T) {
 	}
 }
 
-// Regression: an embedded qualified pointer type tagged `json:"-"` (e.g.
-// `*mail.Address `json:"-"``) previously caused a nil-pointer panic because
-// the first field-walk pass tried to resolve the embed before checking the
-// JSON tag. The fix is to honor `json:"-"` in that pass too. We also
-// verify the embed is absent from the resulting Reference.Fields and the
-// referenced external type is not pulled into prog.References.
+// Regression: an embedded qualified pointer type tagged json:"-" (for
+// example *mail.Address with a json:"-" tag) previously caused a
+// nil-pointer panic because the first field-walk pass tried to resolve
+// the embed before checking the tag. The fix is to honor json:"-" in
+// that pass too. We also verify the embed is absent from the resulting
+// Reference.Fields and the referenced external type is not pulled into
+// prog.References.
 func TestGetReference_EmbedJSONDash(t *testing.T) {
 	prog := NewProgram(false)
 	prog.Config.StructTag = "json"

--- a/docparse/find.go
+++ b/docparse/find.go
@@ -438,6 +438,15 @@ func GetReference(prog *Program, context string, isEmbed bool, lookup, filePath 
 				continue
 			}
 
+			// Skip embedded fields explicitly excluded from the schema
+			// (e.g. `json:"-"`). The nested-walk loop below applies the
+			// same skip; doing it here too avoids resolving a type we
+			// will not emit, which matters for embeds whose underlying
+			// type would otherwise pull in a large external graph.
+			if goutil.TagName(f, tagName) == "-" {
+				continue
+			}
+
 			switch t := f.Type.(type) {
 			case *ast.Ident:
 				err = resolveType(prog, context, false, t, "", pkg)

--- a/docparse/test.go
+++ b/docparse/test.go
@@ -1,5 +1,7 @@
 package docparse
 
+import "net/mail"
+
 // For tests. We don't parse test files.
 
 // testObject general documentation.
@@ -15,4 +17,16 @@ type testObject struct {
 	Foo string
 
 	Bar []string
+}
+
+// testEmbedJSONDash covers the case where a struct embeds a qualified
+// pointer type purely for Go-level method promotion and excludes it from
+// the schema with `json:"-"`. The embed must not be resolved.
+//
+//nolint:unused
+type testEmbedJSONDash struct {
+	*mail.Address `json:"-"`
+
+	// ID documentation {required}.
+	ID int
 }


### PR DESCRIPTION
**The human is talking in this part:**

Hey lads, I don't really know kommentaar that well to delve in myself so I got the robots to do it for me. I have come across what I think is a bug but maybe I'm missing something intentional in kommentaars design (go panic aside). Either way, would be good to get eyes on this and tell me if we've got a genuine fix here.

We came across this in a private repo, specifically in a case like this:

```
type PaymentMethod struct {
    *stripe.PaymentMethod `json:"-"`
    ...
}
```
Where that struct is returned in a handler that we annotate for kommentaar

Running kommentaar against our repo with this would result in a panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x44d0a4]

goroutine 1 [running]:
github.com/teamwork/kommentaar/docparse.resolveType(0x15b34fed37a0, {0x5cb293, 0x4}, 0x0, 0x15b35017fa83?, {0x0, 0x0}, {0x15b350507b01?, 0x8000000000?})
	/go/src/github.com/teamwork/kommentaar/docparse/find.go:764 +0x34
github.com/teamwork/kommentaar/docparse.GetReference(0x15b34fed37a0, {0x5cb293, 0x4}, 0x0, {0x15b35017fa80, 0x10}, {0x15b350005180, 0x46})
	/go/src/github.com/teamwork/kommentaar/docparse/find.go:446 +0xdb0
github.com/teamwork/kommentaar/docparse.resolveType(0x15b34fed37a0, {0x5cb293, 0x4}, 0x0, 0x15b350236820?, {0x15b350005180, 0x46}, {0x15b3500b9126?, 0x2?})
	/go/src/github.com/teamwork/kommentaar/docparse/find.go:788 +0x16c
github.com/teamwork/kommentaar/docparse.findNested(0x15b34fed37a0, {0x5cb293, 0x4}, 0x0, 0x564880?, {0x15b350005180, 0x46}, {0x15b3504891c8?, 0x15b350424090?})
	/go/src/github.com/teamwork/kommentaar/docparse/find.go:753 +0x628
github.com/teamwork/kommentaar/docparse.GetReference(0x15b34fed37a0, {0x5cb293, 0x4}, 0x0, {0x15b3501f0099, 0x16}, {0x15b34fec4140, 0x46})
	/go/src/github.com/teamwork/kommentaar/docparse/find.go:526 +0x1390
github.com/teamwork/kommentaar/docparse.parseRefValue(0x15b34fed37a0, {0x5cb293, 0x4}, {0x15b3501f0099, 0x16}, {0x15b34fec4140, 0x46})
	/go/src/github.com/teamwork/kommentaar/docparse/docparse.go:508 +0xb8
github.com/teamwork/kommentaar/docparse.ParseResponse(0x15b34fed37a0, {0x15b34fec4140, 0x46}, {0x15b3501f008b, 0x24})
	/go/src/github.com/teamwork/kommentaar/docparse/docparse.go:435 +0x128
github.com/teamwork/kommentaar/docparse.parseComment(0x15b34fed37a0, {0x15b3501f0000, 0xe0}, {0x0?, 0x0?}, {0x15b34fec4140, 0x46})
	/go/src/github.com/teamwork/kommentaar/docparse/docparse.go:329 +0x768
github.com/teamwork/kommentaar/docparse.FindComments({0x60ba48, 0x15b34fdea068}, 0x15b34fed37a0)
	/go/src/github.com/teamwork/kommentaar/docparse/find.go:50 +0x318
main.start()
	/go/src/github.com/teamwork/kommentaar/main.go:91 +0x4ac
main.main()
	/go/src/github.com/teamwork/kommentaar/main.go:23 +0x48
---exit: 0---
```

We did a workaround for the moment by stripping all embedded fields with `json:"-"` before kommentaar runs but its probably better its fixed here instead.

---
**Robot talking:**

## Summary

`GetReference` walks struct fields in two passes. The first pass resolves embedded types (so they can be merged later); the second walks nested types for non-embed fields. The second pass already skips fields tagged `json:"-"`, but the first pass does not — so an embed marked `json:"-"` was still resolved despite being excluded from the schema.

For an embedded **qualified pointer type** (e.g. `*pkg.Type` with `json:"-"`), the first-pass `StarExpr` branch additionally asserts `t.X.(*ast.Ident)`, which fails silently for `*ast.SelectorExpr` and passes `nil` to `resolveType` — panicking on `typ.Obj`.

## Reproducing the bug

A common Go pattern that hits this: embed a third-party type for method promotion, hide it from JSON output. To reproduce end-to-end:

**1. Create a minimal package:**

```bash
mkdir -p /tmp/repro/contacts
cd /tmp/repro

cat > go.mod <<'GOMOD'
module repro
go 1.23
GOMOD

cat > contacts/contacts.go <<'GO'
package contacts

import "net/mail"

// Contact wraps mail.Address with a display name.
type Contact struct {
    *mail.Address `json:"-"`

    DisplayName string `json:"displayName"`
}

// GET /contacts
//
// Response 200: Contact
func ListContacts() {}
GO

cat > kommentaar.conf <<'CONF'
title Repro
version 1.0
struct-tag json
CONF
```

**2. Run kommentaar against `master`:**

```bash
git -C /path/to/kommentaar checkout master
go -C /path/to/kommentaar build -o /tmp/kommentaar-master .

cd /tmp/repro
/tmp/kommentaar-master -config kommentaar.conf -output openapi2-yaml ./contacts
```

Expected on master:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18]
  docparse.resolveType   find.go:764
  docparse.GetReference  find.go:446
  docparse.parseRefValue docparse.go:508
  ...
```

**3. Run against this branch:**

```bash
git -C /path/to/kommentaar checkout fix-embed-json-dash
go -C /path/to/kommentaar build -o /tmp/kommentaar-fixed .

cd /tmp/repro
/tmp/kommentaar-fixed -config kommentaar.conf -output openapi2-yaml ./contacts
```

Expected on this branch (exit 0, valid swagger with the embed correctly excluded):
```yaml
definitions:
  contacts.Contact:
    title: Contact
    description: Contact wraps mail.Address with a display name.
    type: object
    properties:
      displayName:
        type: string
```

## What changed

- `docparse/find.go`: skip `json:"-"` embeds in the first field-walk pass, mirroring the existing skip in the nested-walk pass below. This also sidesteps the unsafe `*ast.Ident` assertion for the most common crash case.
- `docparse/test.go`: add `testEmbedJSONDash` fixture — `*mail.Address \`json:"-"\`` embedded alongside a regular field.
- `docparse/docparse_test.go`: add `TestGetReference_EmbedJSONDash` covering the panic regression and asserting `mail.Address` is not pulled into `prog.References`.

To just run the new unit test:
```bash
go test -run TestGetReference_EmbedJSONDash ./docparse/
```

## Not addressed here

The `t.X.(*ast.Ident)` assertion in the first pass is still unsafe — embedding a `*pkg.Type` *without* `json:"-"` will still nil-panic. Worth a separate fix; kept out of this PR to stay minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)