### PR TITLE
Add -out flag to write output to a file instead of stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main // import "github.com/teamwork/kommentaar"
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io"
@@ -43,6 +44,7 @@ func start() (bool, error) {
 	openapi2-jsonindent  OpenAPI/Swagger 2.0 as JSON indented
 	html                 HTML documentation
 `)
+	outFile := flag.String("out", "", "write output to this file instead of stdout")
 	cpuprofile := flag.String("cpuprofile", "", "write cpu profile to `file`")
 	memprofile := flag.String("memprofile", "", "write memory profile to `file`")
 
@@ -88,9 +90,22 @@ func start() (bool, error) {
 		prog.Config.Packages = []string{"."}
 	}
 
-	err := docparse.FindComments(stdout, prog)
+	w := stdout
+	var buf *bytes.Buffer
+	if *outFile != "" {
+		buf = &bytes.Buffer{}
+		w = buf
+	}
+
+	err := docparse.FindComments(w, prog)
 	if err != nil {
 		return false, err
+	}
+
+	if *outFile != "" {
+		if err := os.WriteFile(*outFile, buf.Bytes(), 0666); err != nil {
+			return false, fmt.Errorf("writing output file: %w", err)
+		}
 	}
 
 	if *memprofile != "" {

--- a/run.sh
+++ b/run.sh
@@ -40,4 +40,4 @@ export GOPATH=/go
 export GO111MODULE=off
 
 cd /go/src/$MODULE_PATH
-/go/bin/kommentaar -config $config -output $output $exec_path > /output/swagger.$output_ext
+/go/bin/kommentaar -config $config -output $output -out /output/swagger.$output_ext $exec_path


### PR DESCRIPTION
## Summary

- Adds a `-out <file>` flag that writes output to a file rather than stdout
- When using shell redirection (`kommentaar > output.yaml`), the shell truncates the file before kommentaar starts writing, leaving a window where the file is empty or partially written — editors and tools watching the file see a large spurious diff during generation
- The new flag buffers output in memory then writes the complete content in one shot, so the target file is only replaced once fully ready
- `run.sh` is updated to use `-out` instead of shell redirection

## Test plan

- [ ] Run `kommentaar -out swagger.yaml ./...` and confirm the output file is never empty or partial during generation
- [ ] Confirm `kommentaar ./... > swagger.yaml` (old shell redirect) still works as before
- [ ] Confirm `run.sh`-based Docker invocations produce the same output as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)