### PR TITLE
ci: move off deprecated node20 actions, single-source the Go version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
           cache: false
 
       - name: Lint
@@ -21,13 +21,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v6
-      with:
-        go-version: '1.26'
-
     - uses: actions/checkout@v6
       with:
         path: gopath/src/github.com/teamwork/kommentaar
+
+    - uses: actions/setup-go@v6
+      with:
+        go-version-file: gopath/src/github.com/teamwork/kommentaar/go.mod
 
     - name: Test & coverage
       env:
@@ -58,11 +58,11 @@ jobs:
     steps:
 
     - uses: actions/checkout@v6
-    - uses: docker/setup-qemu-action@v3
-    - uses: docker/setup-buildx-action@v3
+    - uses: docker/setup-qemu-action@v4
+    - uses: docker/setup-buildx-action@v4
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -70,12 +70,12 @@ jobs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,7 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version-file: gopath/src/github.com/teamwork/kommentaar/go.mod
+        cache-dependency-path: gopath/src/github.com/teamwork/kommentaar/go.sum
 
     - name: Test & coverage
       env:


### PR DESCRIPTION
GitHub is deprecating the `node20` Actions runtime. This moves every affected action off it, and removes a version-duplication papercut while in there.

## Changes

- **node20 → node24.** Checked the `runs.using:` each pinned action actually declares (rather than inferring from version numbers). The `lint`/`test` actions were already on node24; all five Docker actions in the `build` job were `node20`:
  - `docker/setup-qemu-action` v3 → **v4**
  - `docker/setup-buildx-action` v3 → **v4**
  - `docker/login-action` v3 → **v4**
  - `docker/metadata-action` v5 → **v6**
  - `docker/build-push-action` v5 → **v7**

  No `with:` blocks changed. The breaking changes in these majors (ESM internals, removed deprecated inputs/outputs, removed `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS`) don't touch any input this workflow uses.

- **Go version from `go.mod`.** `1.26` was hardcoded in `setup-go` in both jobs *and* in `go.mod` — three places to bump. Both jobs now use `go-version-file`. This required moving `checkout` ahead of `setup-go` in the `test` job, since `go-version-file` is read from disk.

- **Fixed a pre-existing cache warning.** The `test` job checks out into `gopath/src/github.com/teamwork/kommentaar`, so setup-go's cache looked for a dependencies file at the workspace root, found none, and logged `Restore cache failed` on every run (including on `master` today). Now pointed at the `go.sum` that checkout actually writes.

## Verification

`lint` + `test` are covered by CI on this PR: setup-go resolves **go1.26.4** from `go.mod` in both jobs, and the cache now saves/restores.

**The `build` job is gated on `refs/tags/v*`, so CI on this PR skips it entirely — a green check here says nothing about the five Docker action bumps.** It was therefore verified manually by pushing a throwaway tag (`v0.0.0-node24-test`) at these changes:

▶️ **[Build and push image — run 29328685719](https://github.com/Teamwork/kommentaar/actions/runs/29328685719/job/87071278846)** ✅

That run confirms:
- **Zero `node20` references** anywhere in the log — all five bumped actions load and run on the node24 runtime.
- A successful `linux/amd64,linux/arm64` multi-arch manifest built and **pushed to `ghcr.io`**, so the full `login-action@v4` → `build-push-action@v7` registry path works, not just the build.

For that run only, `metadata-action` was temporarily pinned with `flavor: latest=false` so the throwaway tag could not clobber the production `latest` tag (the default `latest=auto` **does** apply to `type=ref,event=tag`, which this workflow uses). That pin was reverted and is **not** part of this PR. The test tag and its `ghcr.io` package version have since been deleted; `latest` still points at `v0.3.3`, untouched.

## Notes

- The new majors require Actions Runner **v2.327.1+**. `ubuntu-latest` satisfies this; only relevant if self-hosted runners are introduced.
- Out of scope, but noticed: the `test` job still runs `GO111MODULE: "off"` in GOPATH mode, which is the only reason those `gopath/src/...` paths appear in the setup-go inputs. Worth retiring separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)